### PR TITLE
feat: implemented chunking of docs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,6 @@
             "env": {
                 "GEVENT_SUPPORT": "False"
             }
-        }
+        },
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,11 +6,16 @@
   "[python]": {
     "editor.codeActionsOnSave": {
       "source.organizeImports": true
-    }
+    },
   },
   "terminal.integrated.env.linux": {
     "PYTHONPATH": ".:tests"
   },
   "python.analysis.extraPaths": [],
-  "python.defaultInterpreterPath": ".venv/bin/python"
+  "python.defaultInterpreterPath": ".venv/bin/python",
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/adsingestp/parsers/base.py
+++ b/adsingestp/parsers/base.py
@@ -1,3 +1,5 @@
+import re
+
 import bs4
 import xmltodict as xmltodict_parser
 
@@ -51,6 +53,31 @@ class BaseXmlToDictParser(object):
             return d
         else:
             return d
+
+    def get_chunks(self, input, startpattern, endpattern):
+        """Super simple method (though not inefficient) to cut input
+        into chunk-sized documents, preserving header/footer"""
+
+        s = re.compile(startpattern, re.IGNORECASE)
+        e = re.compile(endpattern, re.IGNORECASE)
+        x = s.search(input)
+        if x is None:
+            return input  # not found, return the whole thing
+        istart = x.start()
+        iend = None
+        for x in e.finditer(input, istart + 1):
+            iend = x.end() + 1
+        if iend is None:
+            return input  # not found, return the whole thing
+
+        header = input[0:istart]
+        footer = input[iend:]
+
+        for snext in s.finditer(input, istart + 1):
+            yield header + input[istart : snext.start()] + footer
+            istart = snext.start()
+
+        yield header + input[istart:iend] + footer
 
 
 class BaseBeautifulSoupParser(object):

--- a/adsingestp/parsers/datacite.py
+++ b/adsingestp/parsers/datacite.py
@@ -222,29 +222,30 @@ class DataciteParser(BaseXmlToDictParser):
         self.base_metadata["doctype"] = doctype
 
     def parse(self, text):
-        d = self.xmltodict(text)
+        for chunk in self.get_chunks(text, r"<resource\b[^>]*>", r"</resource\b[^>]*>"):
+            d = self.xmltodict(chunk)
 
-        # as a convenience, remove the OAI wrapper if it's there
-        self.input_metadata = d.get("record", {}).get("metadata", {}).get("resource") or d.get(
-            "resource"
-        )
+            # as a convenience, remove the OAI wrapper if it's there
+            self.input_metadata = d.get("record", {}).get("metadata", {}).get("resource") or d.get(
+                "resource"
+            )
 
-        # check for namespace to make sure it's a compatible datacite schema
-        schema = self.input_metadata.get("@xmlns")
-        if schema not in self.DC_SCHEMAS:
-            raise WrongSchemaException('Unexpected XML schema "%s"' % schema)
+            # check for namespace to make sure it's a compatible datacite schema
+            schema = self.input_metadata.get("@xmlns")
+            if schema not in self.DC_SCHEMAS:
+                raise WrongSchemaException('Unexpected XML schema "%s"' % schema)
 
-        self._parse_contrib(author=True)
-        self._parse_contrib(author=False)
-        self._parse_title_abstract()
-        self._parse_publisher()
-        self._parse_pubdate()
-        self._parse_keywords()
-        self._parse_ids()
-        self._parse_related_refs()
-        self._parse_permissions()
-        self._parse_doctype()
+            self._parse_contrib(author=True)
+            self._parse_contrib(author=False)
+            self._parse_title_abstract()
+            self._parse_publisher()
+            self._parse_pubdate()
+            self._parse_keywords()
+            self._parse_ids()
+            self._parse_related_refs()
+            self._parse_permissions()
+            self._parse_doctype()
 
-        output = serializer.serialize(self.base_metadata, format="OtherXML")
+            output = serializer.serialize(self.base_metadata, format="OtherXML")
 
-        return output
+            yield output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ packages = [
 ]
 
 dependencies = [
-    'click>=8.0.3',
+    'click==8.0.3',
     'beautifulsoup4==4.10.0',
     'lxml==4.7.1',
     'namedentities==1.9.4',

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -29,14 +29,14 @@ class TestArxiv(unittest.TestCase):
             test_outfile = os.path.join(self.outputdir, f + ".json")
             parser = arxiv.ArxivParser()
 
-            with open(test_infile, "rb") as fp:
+            with open(test_infile, "r") as fp:
                 input_data = fp.read()
 
-            with open(test_outfile, "rb") as fp:
+            with open(test_outfile, "r") as fp:
                 output_text = fp.read()
                 output_data = json.loads(output_text)
 
-            parsed = parser.parse(input_data)
+            parsed = list(parser.parse(input_data))[0]
 
             # make sure this is valid schema
             try:
@@ -54,3 +54,7 @@ class TestArxiv(unittest.TestCase):
             parsed["recordData"]["parsedTime"] = ""
 
             self.assertEqual(parsed, output_data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+
+from adsingestp.parsers import base
+
+
+class TestBase(unittest.TestCase):
+    def setUp(self):
+        stubdata_dir = os.path.join(os.path.dirname(__file__), "stubdata/")
+        self.inputdir = os.path.join(stubdata_dir, "input")
+        self.outputdir = os.path.join(stubdata_dir, "output")
+
+    def test_chunks(self):
+        class MyParser(base.BaseXmlToDictParser):
+            pass
+
+        parser = MyParser()
+
+        input = """<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article SYSTEM "http://jats.nlm.nih.gov/archiving/1.2/JATS-archivearticle1.dtd"><article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.2" article-type="research-article" xml:lang="en"><front>foo</front></article><article><title>hey1</title></article> <article ><title>hey2</title></article></footer>"""
+
+        papers = list(parser.get_chunks(input, r"<article[^>]*>", r"</article[^>]*>"))
+
+        expected = [
+            '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article SYSTEM "http://jats.nlm.nih.gov/archiving/1.2/JATS-archivearticle1.dtd"><article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.2" article-type="research-article" xml:lang="en"><front>foo</front></article>/footer>',
+            '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article SYSTEM "http://jats.nlm.nih.gov/archiving/1.2/JATS-archivearticle1.dtd"><article><title>hey1</title></article> /footer>',
+            '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article SYSTEM "http://jats.nlm.nih.gov/archiving/1.2/JATS-archivearticle1.dtd"><article ><title>hey2</title></article></footer>',
+        ]
+
+        assert papers == expected
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_crossref.py
+++ b/tests/test_crossref.py
@@ -33,14 +33,14 @@ class TestCrossref(unittest.TestCase):
             test_outfile = os.path.join(self.outputdir, f + ".json")
             parser = crossref.CrossrefParser()
 
-            with open(test_infile, "rb") as fp:
+            with open(test_infile, "r") as fp:
                 input_data = fp.read()
 
-            with open(test_outfile, "rb") as fp:
+            with open(test_outfile, "r") as fp:
                 output_text = fp.read()
                 output_data = json.loads(output_text)
 
-            parsed = parser.parse(input_data)
+            parsed = list(parser.parse(input_data))[0]
 
             # make sure this is valid schema
             try:

--- a/tests/test_datacite.py
+++ b/tests/test_datacite.py
@@ -37,14 +37,14 @@ class TestDatacite(unittest.TestCase):
             test_outfile = os.path.join(self.outputdir, f + ".json")
             parser = datacite.DataciteParser()
 
-            with open(test_infile, "rb") as fp:
+            with open(test_infile, "r") as fp:
                 input_data = fp.read()
 
-            with open(test_outfile, "rb") as fp:
+            with open(test_outfile, "r") as fp:
                 output_text = fp.read()
                 output_data = json.loads(output_text)
 
-            parsed = parser.parse(input_data)
+            parsed = list(parser.parse(input_data))[0]
 
             # make sure this is valid schema
             try:
@@ -62,3 +62,7 @@ class TestDatacite(unittest.TestCase):
             parsed["recordData"]["parsedTime"] = ""
 
             self.assertEqual(parsed, output_data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implemented the basic recognition of chunks - this will work as long as a regex can be constructed which identifies valid start/end tags; will also work on non xml content - but it will fail if there is a nested structure, such as `//article/list/foo/article` - in which case the parser should decide to parse the xml document and go through the top level elements.