### PR TITLE
 	fix: modified crossref parser to accept ISSN with 'X' in last decimal

### DIFF
--- a/adsingestp/parsers/crossref.py
+++ b/adsingestp/parsers/crossref.py
@@ -11,6 +11,8 @@ from adsingestp.parsers.base import BaseBeautifulSoupParser
 
 logger = logging.getLogger(__name__)
 
+# compile outside of the class definition -- it only needs to be compiled once
+re_issn = re.compile(r"^\d{4}-?\d{3}[0-9X]$")  # XXXX-XXXX
 
 class CrossrefParser(BaseBeautifulSoupParser):
     def __init__(self):
@@ -78,7 +80,6 @@ class CrossrefParser(BaseBeautifulSoupParser):
             issn_all = []
 
         issns = []
-        re_issn = re.compile(r"^\d{4}-\d{4}$")  # XXXX-XXXX
         for i in issn_all:
             if i.get_text() and re_issn.match(i.get_text()):
                 issns.append((i["media_type"], i.get_text()))


### PR DESCRIPTION
Made two changes to crossref.py:
- moved the re_issn compile outside of the class method definition.  If left where it was, re will recompile the definition every time you use the function.  It only needs to be compiled once when the code is run.
- Modified the regular expression to allow both ISSNs without a dash between the 4-digit groups, and to allow cases where the last digit is an "X" rather than an integer.