### PR TITLE
Fix: improved exception handling in crossref

### DIFF
--- a/adsingestp/parsers/base.py
+++ b/adsingestp/parsers/base.py
@@ -217,7 +217,7 @@ class IngestBase(object):
                     "affiliation": [
                         {
                             "affPubRaw": j,
-                            "affPubID": i.get["xaff"][idx] if i.get("xaff") else "",
+                            "affPubID": i.get["xaff"][idx] if i.get("xaff") else ""
                             # "affPubIDType": "XXX"
                         }
                         for idx, j in enumerate(i.get("aff", []))

--- a/adsingestp/parsers/base.py
+++ b/adsingestp/parsers/base.py
@@ -217,7 +217,7 @@ class IngestBase(object):
                     "affiliation": [
                         {
                             "affPubRaw": j,
-                            "affPubID": i.get["xaff"][idx] if i.get("xaff") else ""
+                            "affPubID": i.get("xaff")[idx] if i.get("xaff") else ""
                             # "affPubIDType": "XXX"
                         }
                         for idx, j in enumerate(i.get("aff", []))

--- a/adsingestp/parsers/base.py
+++ b/adsingestp/parsers/base.py
@@ -183,7 +183,7 @@ class IngestBase(object):
                 "affiliation": [
                     {
                         "affPubRaw": j,
-                        "affPubID": i.get("aff")[idx] if i.get("aff") else "",
+                        "affPubID": i.get("xaff")[idx] if i.get("xaff") else "",
                         # "affPubIDType": "XXX" # TODO ask MT
                     }
                     for idx, j in enumerate(i.get("aff", []))
@@ -217,7 +217,7 @@ class IngestBase(object):
                     "affiliation": [
                         {
                             "affPubRaw": j,
-                            "affPubID": i.get("aff")[idx] if i.get("aff") else ""
+                            "affPubID": i.get("xaff")[idx] if i.get("xaff") else ""
                             # "affPubIDType": "XXX"
                         }
                         for idx, j in enumerate(i.get("aff", []))

--- a/adsingestp/parsers/base.py
+++ b/adsingestp/parsers/base.py
@@ -183,7 +183,7 @@ class IngestBase(object):
                 "affiliation": [
                     {
                         "affPubRaw": j,
-                        "affPubID": i.get("xaff")[idx] if i.get("xaff") else "",
+                        "affPubID": i.get("aff")[idx] if i.get("aff") else "",
                         # "affPubIDType": "XXX" # TODO ask MT
                     }
                     for idx, j in enumerate(i.get("aff", []))
@@ -217,7 +217,7 @@ class IngestBase(object):
                     "affiliation": [
                         {
                             "affPubRaw": j,
-                            "affPubID": i.get("xaff")[idx] if i.get("xaff") else ""
+                            "affPubID": i.get("aff")[idx] if i.get("aff") else ""
                             # "affPubIDType": "XXX"
                         }
                         for idx, j in enumerate(i.get("aff", []))

--- a/adsingestp/parsers/crossref.py
+++ b/adsingestp/parsers/crossref.py
@@ -70,7 +70,9 @@ class CrossrefParser(BaseBeautifulSoupParser):
 
     def _parse_pub(self):
         # journal articles only
-        if self.input_metadata.find("journal") and self.input_metadata.find("journal").find("journal_metadata"):
+        if self.input_metadata.find("journal") and self.input_metadata.find("journal").find(
+            "journal_metadata"
+        ):
             journal_meta = self.input_metadata.find("journal").find("journal_metadata")
             if journal_meta.find("full_title"):
                 self.base_metadata["publication"] = journal_meta.find("full_title").get_text()

--- a/adsingestp/parsers/crossref.py
+++ b/adsingestp/parsers/crossref.py
@@ -70,7 +70,7 @@ class CrossrefParser(BaseBeautifulSoupParser):
 
     def _parse_pub(self):
         # journal articles only
-        if self.input_metadata.find("journal"):
+        if self.input_metadata.find("journal") and self.input_metadata.find("journal").find("journal_metadata"):
             journal_meta = self.input_metadata.find("journal").find("journal_metadata")
             if journal_meta.find("full_title"):
                 self.base_metadata["publication"] = journal_meta.find("full_title").get_text()
@@ -209,7 +209,7 @@ class CrossrefParser(BaseBeautifulSoupParser):
             if p.get("media_type"):
                 datetype = p.get("media_type")
             else:
-                logger.warn("Pubdate without a media type, assigning print.")
+                logger.warning("Pubdate without a media type, assigning print.")
                 datetype = "print"
 
             pubdate = self._get_date(p)

--- a/adsingestp/parsers/crossref.py
+++ b/adsingestp/parsers/crossref.py
@@ -70,20 +70,28 @@ class CrossrefParser(BaseBeautifulSoupParser):
 
     def _parse_pub(self):
         # journal articles only
-        journal_meta = self.input_metadata.find("journal").find("journal_metadata")
+        if self.input_metadata.find("journal"):
+            journal_meta = self.input_metadata.find("journal").find("journal_metadata")
+            if journal_meta.find("full_title"):
+                self.base_metadata["publication"] = journal_meta.find("full_title").get_text()
 
-        if journal_meta.find("full_title"):
-            self.base_metadata["publication"] = journal_meta.find("full_title").get_text()
-
-        if journal_meta.find_all("issn"):
-            issn_all = journal_meta.find_all("issn")
+            else:
+                self.base_metadata["publication"] = None
+            if journal_meta.find_all("issn"):
+                issn_all = journal_meta.find_all("issn")
+            else:
+                issn_all = []
         else:
+            self.base_metadata["publication"] = None
             issn_all = []
 
         issns = []
         for i in issn_all:
             if i.get_text() and re_issn.match(i.get_text()):
-                issns.append((i["media_type"], i.get_text()))
+                if i.get("media_type"):
+                    issns.append((i["media_type"], i.get_text()))
+                else:
+                    issns.append(("print", i.get_text()))
         self.base_metadata["issn"] = issns
 
     def _parse_issue(self):
@@ -198,7 +206,11 @@ class CrossrefParser(BaseBeautifulSoupParser):
     def _parse_pubdate(self):
         pubdates_raw = self.record_meta.find_all("publication_date")
         for p in pubdates_raw:
-            datetype = p.get("media_type", "print")
+            if p.get("media_type"):
+                datetype = p.get("media_type")
+            else:
+                logger.warn("Pubdate without a media type, assigning print.")
+                datetype = "print"
 
             pubdate = self._get_date(p)
             if datetype == "print":
@@ -206,7 +218,7 @@ class CrossrefParser(BaseBeautifulSoupParser):
             elif datetype == "online":
                 self.base_metadata["pubdate_electronic"] = pubdate
             else:
-                logger.warning("Unknown date type")
+                logger.warning("Unknown date type: %s" % datetype)
 
     def _parse_edhistory_copyright(self):
         if self.record_meta.find("crossmark") and self.record_meta.find("crossmark").find(
@@ -234,7 +246,7 @@ class CrossrefParser(BaseBeautifulSoupParser):
                 self.base_metadata["page_first"] = page_info.find("first_page").get_text()
 
             if page_info.find("last_page"):
-                self.base_metadata["page_last"] = page_info.last_page.get_text()
+                self.base_metadata["page_last"] = page_info.find("last_page").get_text()
 
         elif self.record_meta.find("publisher_item") and self.record_meta.find(
             "publisher_item"
@@ -243,7 +255,10 @@ class CrossrefParser(BaseBeautifulSoupParser):
             for idx, i in enumerate(
                 self.record_meta.find("publisher_item").find_all("item_number")
             ):
-                tag = i.get("item_number_type")
+                if i.get("item_number_type"):
+                    tag = i.get("item_number_type")
+                else:
+                    tag = None
                 ids[tag if tag else "other" + str(idx)] = i.get_text()
             if ids.get("article-number"):
                 self.base_metadata["electronic_id"] = ids["article-number"]
@@ -296,14 +311,20 @@ class CrossrefParser(BaseBeautifulSoupParser):
         if self.input_metadata.find("journal"):
             type_found = True
             self.record_type = "journal"
-            self.record_meta = self.input_metadata.find("journal_article").extract()
+            if self.input_metadata.find("journal_article"):
+                self.record_meta = self.input_metadata.find("journal_article").extract()
+            else:
+                self.record_meta = None
         if self.input_metadata.find("conference"):
             if type_found:
                 raise WrongSchemaException("Too many document types found in CrossRef record")
             else:
                 type_found = True
                 self.record_type = "conference"
-                self.record_meta = self.input_metadata.find("conference_paper").extract()
+                if self.input_metadata.find("conference_paper"):
+                    self.record_meta = self.input_metadata.find("conference_paper").extract()
+                else:
+                    self.record_meta = None
         if self.input_metadata.find("book"):
             if type_found:
                 raise WrongSchemaException("Too many document types found in CrossRef record")
@@ -314,10 +335,16 @@ class CrossrefParser(BaseBeautifulSoupParser):
                     self.record_meta = self.input_metadata.find("book_metadata").extract()
                 elif self.input_metadata.find("book_series_metadata"):
                     self.record_meta = self.input_metadata.find("book_series_metadata").extract()
+                else:
+                    self.record_meta = None
 
         if not type_found:
             raise WrongSchemaException(
                 "Didn't find allowed document type (article, conference, book) in CrossRef record"
+            )
+        elif not self.record_meta:
+            raise WrongSchemaException(
+                "Null record_meta for document type %s in CrossRef record" % self.record_type
             )
 
         if self.record_type == "journal":

--- a/adsingestp/parsers/jats.py
+++ b/adsingestp/parsers/jats.py
@@ -485,7 +485,7 @@ class JATSParser(BaseBeautifulSoupParser):
                 month_name = month_raw[0:3].lower()
                 month = utils.MONTH_TO_NUMBER[month_name]
 
-            if int(month) < 10 and len(month) < 2:
+            if int(month) < 10 and len(str(month)) < 2:
                 month = "0" + str(int(month))
             else:
                 month = str(month)
@@ -500,7 +500,7 @@ class JATSParser(BaseBeautifulSoupParser):
             else:
                 day = "00"
 
-            if int(day) < 10 and len(day) < 2:
+            if int(day) < 10 and len(str(day)) < 2:
                 day = "0" + str(int(day))
             else:
                 day = str(day)
@@ -820,7 +820,10 @@ class JATSParser(BaseBeautifulSoupParser):
     def _parse_references(self):
         if self.back_meta is not None:
             ref_list_text = []
-            ref_results = self.back_meta.find("ref-list").find_all("ref")
+            if self.back_meta.find("ref-list"):
+                ref_results = self.back_meta.find("ref-list").find_all("ref")
+            else:
+                ref_results = []
             for r in ref_results:
                 # output raw XML for reference service to parse later
                 s = str(r.extract()).replace("\n", " ")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     'lxml==4.7.1',
     'nameparser==1.1.1',
     'python-dateutil==2.8.1',
-    'adsingestschema @ git+https://github.com/adsabs/ingest_data_model@v1.0.6#egg=adsingestschema',
+    'adsingestschema @ git+https://github.com/adsabs/ingest_data_model@v1.0.7#egg=adsingestschema',
 ]
 
 

--- a/tests/test_jats.py
+++ b/tests/test_jats.py
@@ -24,6 +24,7 @@ class TestJATS(unittest.TestCase):
         stubdata_dir = os.path.join(os.path.dirname(__file__), "stubdata/")
         self.inputdir = os.path.join(stubdata_dir, "input")
         self.outputdir = os.path.join(stubdata_dir, "output")
+        self.maxDiff = None
 
     def test_jats(self):
 


### PR DESCRIPTION
There are cases where the crossref record is missing data fields due to publisher errors.  These fixes will alleviate many of the observed cases where page numbers and other data are missing.