### PR TITLE
Fix: adds datacite tests for Zenodo records, moves _detag function fr…

### DIFF
--- a/adsingestp/parsers/base.py
+++ b/adsingestp/parsers/base.py
@@ -471,7 +471,9 @@ class BaseBeautifulSoupParser(IngestBase):
     out of the input XML stream.
     """
 
-    fix_ampersand = re.compile(r"(&amp;)(.*?)(;)")
+    fix_ampersand_1 = re.compile(r"(__amp__)(.*?)(;)")
+    fix_ampersand_2 = re.compile(r"(&amp;)(.*?)(;)")
+    re_ampersands = [fix_ampersand_1, fix_ampersand_2]
 
     HTML_TAGS_MATH = [
         "inline-formula",
@@ -540,11 +542,12 @@ class BaseBeautifulSoupParser(IngestBase):
         # Everything after this point is string manipulation.
         newr = str(newr)
 
-        amp_fix = self.fix_ampersand.findall(newr)
-        for s in amp_fix:
-            s_old = "".join(s)
-            s_new = "&" + s[1] + ";"
-            newr = newr.replace(s_old, s_new)
+        for reamp in self.re_ampersands:
+            amp_fix = reamp.findall(newr)
+            for s in amp_fix:
+                s_old = "".join(s)
+                s_new = "&" + s[1] + ";"
+                newr = newr.replace(s_old, s_new)
 
         newr = re.sub("\\s+|\n+|\r+", " ", newr)
         newr = newr.replace("&nbsp;", " ")

--- a/adsingestp/parsers/base.py
+++ b/adsingestp/parsers/base.py
@@ -471,6 +471,35 @@ class BaseBeautifulSoupParser(IngestBase):
     out of the input XML stream.
     """
 
+    fix_ampersand = re.compile(r"(&amp;)(.*?)(;)")
+
+    HTML_TAGS_MATH = [
+        "inline-formula",
+        "tex-math",
+        "mml:math",
+        "mml:semantics",
+        "mml:mrow",
+        "mml:munder",
+        "mml:mo",
+        "mml:mi",
+        "mml:msub",
+        "mml:mover",
+        "mml:mn",
+        "mml:annotation",
+    ]
+
+    HTML_TAGS_HTML = ["sub", "sup", "a", "astrobj"]
+
+    HTML_TAGSET = {
+        "title": HTML_TAGS_MATH + HTML_TAGS_HTML,
+        "abstract": HTML_TAGS_MATH + HTML_TAGS_HTML + ["pre", "br"],
+        "comments": HTML_TAGS_MATH + HTML_TAGS_HTML + ["pre", "br"],
+        "affiliations": ["email", "orcid"],
+        "keywords": ["astrobj"],
+    }
+
+    HTML_TAGS_DANGER = ["php", "script", "css"]
+
     def bsstrtodict(self, input_xml, parser="lxml-xml"):
         """
         Returns a BeautifulSoup tree given an XML text
@@ -480,3 +509,45 @@ class BaseBeautifulSoupParser(IngestBase):
         """
 
         return bs4.BeautifulSoup(input_xml, parser)
+
+    def _detag(self, r, tags_keep):
+        """
+        Removes tags from input BeautifulSoup object
+        :param r: BeautifulSoup object (not string)
+        :param tags_keep: this function will remove all tags except those passed here
+        :return: newr: striing with cleaned text
+        """
+        # note that parser=lxml is recommended here - if the more stringent lxml-xml is used,
+        # the output is slightly different and the code will need to be modified
+        newr = self.bsstrtodict(str(r), "lxml")
+        if newr.find_all():
+            tag_list = list(set([x.name for x in newr.find_all()]))
+        else:
+            tag_list = []
+        for t in tag_list:
+            elements = newr.find_all(t)
+            for e in elements:
+                if t in self.HTML_TAGS_DANGER:
+                    e.decompose()
+                elif t in tags_keep:
+                    continue
+                else:
+                    if t.lower() == "sc":
+                        e.string = e.string.upper()
+                    e.unwrap()
+
+        # Note: newr is converted from a bs4 object to a string here.
+        # Everything after this point is string manipulation.
+        newr = str(newr)
+
+        amp_fix = self.fix_ampersand.findall(newr)
+        for s in amp_fix:
+            s_old = "".join(s)
+            s_new = "&" + s[1] + ";"
+            newr = newr.replace(s_old, s_new)
+
+        newr = re.sub("\\s+|\n+|\r+", " ", newr)
+        newr = newr.replace("&nbsp;", " ")
+        newr = newr.strip()
+
+        return newr

--- a/adsingestp/parsers/datacite.py
+++ b/adsingestp/parsers/datacite.py
@@ -123,13 +123,13 @@ class DataciteParser(BaseBeautifulSoupParser):
             if not type_attr:
                 titles[title_attr.lower()] = self._clean_output(t.get_text())
             if type_attr == "Subtitle":
-                self.base_metadata["subtitle"] = self._clean_output(t.get_text())
+                self.base_metadata["subtitle"] = self._detag(self._clean_output(t.get_text()), self.HTML_TAGSET["title"])
         if not titles:
             raise MissingTitleException("No title found")
         # we use the English title as the main one, then add any foreign ones
         # there are several options for "English" in this schema, so check for all of them (lowercase forms).  If no language specified (key is ""), assume English.
         en_key = list({"en", "en-us", ""} & set(titles.keys()))[0]
-        self.base_metadata["title"] = self._clean_output(titles.pop(en_key))
+        self.base_metadata["title"] = self._detag(self._clean_output(titles.pop(en_key)), self.HTML_TAGSET["title"])
         title_foreign = []
         lang_foreign = []
         for tkey in titles:
@@ -138,7 +138,7 @@ class DataciteParser(BaseBeautifulSoupParser):
 
         # the data model only takes a single foreign-language title; will need to adjust if more are required
         if title_foreign:
-            self.base_metadata["title_native"] = self._clean_output(title_foreign[0])
+            self.base_metadata["title_native"] = self._detag(self._clean_output(title_foreign[0]), self.HTML_TAGSET["title"])
             self.base_metadata["lang_native"] = lang_foreign[0]
 
         # abstract, references are all in the "descriptions" section
@@ -153,7 +153,7 @@ class DataciteParser(BaseBeautifulSoupParser):
                     abstract = s.get_text()
 
         if abstract:
-            self.base_metadata["abstract"] = self._clean_output(abstract)
+            self.base_metadata["abstract"] = self._detag(self._clean_output(abstract), self.HTML_TAGSET["abstract"])
 
     def _parse_publisher(self):
         if self.input_metadata.find("publisher"):
@@ -246,8 +246,16 @@ class DataciteParser(BaseBeautifulSoupParser):
                 c = i.get_text()
                 if u == "info:eu-repo/semantics/openAccess" or c == "Open Access":
                     is_oa = True
+                elif "http" in u:
+                    self.base_metadata.setdefault("openAccess", {}).setdefault("licenseURL", u)
+                    if "creativecommon" in u:
+                        is_oa=True
+                    if c:
+                        self.base_metadata.setdefault("openAccess", {}).setdefault("license", c)
+                        if "Creative Common" in c or "GNU General Public License" in c:
+                            is_oa = True
 
-            self.base_metadata["openAccess"]["open"] = is_oa
+            self.base_metadata.setdefault("openAccess", {}).setdefault("open", is_oa)
 
     def _parse_doctype(self):
         if self.input_metadata.find("resourceType"):

--- a/adsingestp/parsers/datacite.py
+++ b/adsingestp/parsers/datacite.py
@@ -123,13 +123,17 @@ class DataciteParser(BaseBeautifulSoupParser):
             if not type_attr:
                 titles[title_attr.lower()] = self._clean_output(t.get_text())
             if type_attr == "Subtitle":
-                self.base_metadata["subtitle"] = self._detag(self._clean_output(t.get_text()), self.HTML_TAGSET["title"])
+                self.base_metadata["subtitle"] = self._detag(
+                    self._clean_output(t.get_text()), self.HTML_TAGSET["title"]
+                )
         if not titles:
             raise MissingTitleException("No title found")
         # we use the English title as the main one, then add any foreign ones
         # there are several options for "English" in this schema, so check for all of them (lowercase forms).  If no language specified (key is ""), assume English.
         en_key = list({"en", "en-us", ""} & set(titles.keys()))[0]
-        self.base_metadata["title"] = self._detag(self._clean_output(titles.pop(en_key)), self.HTML_TAGSET["title"])
+        self.base_metadata["title"] = self._detag(
+            self._clean_output(titles.pop(en_key)), self.HTML_TAGSET["title"]
+        )
         title_foreign = []
         lang_foreign = []
         for tkey in titles:
@@ -138,7 +142,9 @@ class DataciteParser(BaseBeautifulSoupParser):
 
         # the data model only takes a single foreign-language title; will need to adjust if more are required
         if title_foreign:
-            self.base_metadata["title_native"] = self._detag(self._clean_output(title_foreign[0]), self.HTML_TAGSET["title"])
+            self.base_metadata["title_native"] = self._detag(
+                self._clean_output(title_foreign[0]), self.HTML_TAGSET["title"]
+            )
             self.base_metadata["lang_native"] = lang_foreign[0]
 
         # abstract, references are all in the "descriptions" section
@@ -153,7 +159,9 @@ class DataciteParser(BaseBeautifulSoupParser):
                     abstract = s.get_text()
 
         if abstract:
-            self.base_metadata["abstract"] = self._detag(self._clean_output(abstract), self.HTML_TAGSET["abstract"])
+            self.base_metadata["abstract"] = self._detag(
+                self._clean_output(abstract), self.HTML_TAGSET["abstract"]
+            )
 
     def _parse_publisher(self):
         if self.input_metadata.find("publisher"):
@@ -249,7 +257,7 @@ class DataciteParser(BaseBeautifulSoupParser):
                 elif "http" in u:
                     self.base_metadata.setdefault("openAccess", {}).setdefault("licenseURL", u)
                     if "creativecommon" in u:
-                        is_oa=True
+                        is_oa = True
                     if c:
                         self.base_metadata.setdefault("openAccess", {}).setdefault("license", c)
                         if "Creative Common" in c or "GNU General Public License" in c:

--- a/adsingestp/parsers/jats.py
+++ b/adsingestp/parsers/jats.py
@@ -454,7 +454,6 @@ class JATSAffils(object):
 
 
 class JATSParser(BaseBeautifulSoupParser):
-
     def __init__(self):
         self.base_metadata = {}
         self.back_meta = None

--- a/tests/stubdata/input/zenodo_test.xml
+++ b/tests/stubdata/input/zenodo_test.xml
@@ -1,0 +1,44 @@
+<record>
+      <header>
+        <identifier>oai:zenodo.org:34650</identifier>
+        <datestamp>2020-01-20T17:28:18Z</datestamp>
+      </header>
+      <metadata>
+        <resource xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.3/metadata.xsd">
+          <identifier identifierType="DOI">10.5281/zenodo.34650</identifier>
+          <alternateIdentifiers>
+            <alternateIdentifier alternateIdentifierType="oai">oai:zenodo.org:34650</alternateIdentifier>
+          </alternateIdentifiers>
+          <creators>
+            <creator>
+              <creatorName nameType="Personal">Reetz, Johannes</creatorName>
+              <givenName>Johannes</givenName>
+              <familyName>Reetz</familyName>
+              <affiliation>Max Planck Computing and Data Facility, Garching, Germany</affiliation>
+            </creator>
+          </creators>
+          <titles>
+            <title>EUDAT - Open Data Services for Research</title>
+          </titles>
+          <publisher>Zenodo</publisher>
+          <publicationYear>2015</publicationYear>
+          <subjects>
+            <subject>Science data management</subject>
+          </subjects>
+          <dates>
+            <date dateType="Issued">2015-12-03</date>
+          </dates>
+          <resourceType resourceTypeGeneral="Text">Presentation</resourceType>
+          <relatedIdentifiers>
+            <relatedIdentifier relatedIdentifierType="DOI" relationType="IsVersionOf"></relatedIdentifier>
+            <relatedIdentifier relatedIdentifierType="URL" relationType="IsPartOf">https://zenodo.org/communities/sciops2015</relatedIdentifier>
+          </relatedIdentifiers>
+          <rightsList>
+            <rights rightsURI="https://creativecommons.org/licenses/by/4.0/legalcode" rightsIdentifierScheme="spdx" rightsIdentifier="cc-by-4.0">Creative Commons Attribution 4.0 International</rights>
+          </rightsList>
+          <descriptions>
+            <description descriptionType="Abstract">Presentation slides</description>
+          </descriptions>
+        </resource>
+      </metadata>
+    </record>

--- a/tests/stubdata/input/zenodo_test2.xml
+++ b/tests/stubdata/input/zenodo_test2.xml
@@ -1,0 +1,148 @@
+<record>
+      <header>
+        <identifier>oai:zenodo.org:3465853</identifier>
+        <datestamp>2023-07-27T23:03:16Z</datestamp>
+        <setSpec>software</setSpec>
+      </header>
+      <metadata>
+        <resource xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
+          <identifier identifierType="DOI">10.5281/zenodo.3465853</identifier>
+          <creators>
+            <creator>
+              <creatorName>Jay Gambetta</creatorName>
+              <affiliation>@IBM</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Matthew Treinish</creatorName>
+            </creator>
+            <creator>
+              <creatorName>Paul Kassebaum</creatorName>
+              <affiliation>IBM</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Diego M. Rodríguez</creatorName>
+              <affiliation>@IBMResearch</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Salvador de la Puente González</creatorName>
+              <affiliation>@IBMResearch</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Paul Nation</creatorName>
+              <affiliation>IBM</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Shaohan Hu</creatorName>
+              <affiliation>IBM Research</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Laura Zdanski</creatorName>
+              <affiliation>@IBM @openliberty</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Marco Pistoia</creatorName>
+              <affiliation>IBM</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Kevin Krsulich</creatorName>
+            </creator>
+            <creator>
+              <creatorName>Travis-S-IBM</creatorName>
+              <affiliation>IBM</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Juan Gomez</creatorName>
+            </creator>
+            <creator>
+              <creatorName>David McKay</creatorName>
+              <affiliation>@IBM, @Qiskit</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Albert Frisch</creatorName>
+              <affiliation>IBM @QISKit</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Yehuda Naveh</creatorName>
+              <affiliation>IBM Research</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Steve Wood</creatorName>
+              <affiliation>IBM Research</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Zoufalc</creatorName>
+            </creator>
+            <creator>
+              <creatorName>tigerjack</creatorName>
+            </creator>
+            <creator>
+              <creatorName>Shelly Garion</creatorName>
+              <affiliation>IBM</affiliation>
+            </creator>
+            <creator>
+              <creatorName>RohitMidha23</creatorName>
+            </creator>
+            <creator>
+              <creatorName>KaoriNamba</creatorName>
+            </creator>
+            <creator>
+              <creatorName>Juan Cruz-Benito</creatorName>
+              <affiliation>@IBMResearch</affiliation>
+            </creator>
+            <creator>
+              <creatorName>HNorlen</creatorName>
+            </creator>
+            <creator>
+              <creatorName>Francois Varchon</creatorName>
+            </creator>
+            <creator>
+              <creatorName>Christopher J. Wood</creatorName>
+              <affiliation>IBM Research @QISKit</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Blas Osvaldo Gonzalez Aceves</creatorName>
+            </creator>
+            <creator>
+              <creatorName>Baltazar Rodriguez</creatorName>
+              <affiliation>IBM</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Ayumu-walker</creatorName>
+            </creator>
+            <creator>
+              <creatorName>Amano, Takehiko</creatorName>
+              <givenName>Takehiko</givenName>
+              <familyName>Amano</familyName>
+              <affiliation>IBM</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Alex Pozas-Kerstjens</creatorName>
+              <affiliation>ICFO</affiliation>
+            </creator>
+          </creators>
+          <titles>
+            <title>Qiskit/qiskit: Qiskit 0.12.1</title>
+          </titles>
+          <publisher>Zenodo</publisher>
+          <publicationYear>2019</publicationYear>
+          <dates>
+            <date dateType="Issued">2019-09-30</date>
+          </dates>
+          <resourceType resourceTypeGeneral="Software"/>
+          <relatedIdentifiers>
+            <relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementTo">https://github.com/Qiskit/qiskit/tree/0.12.1</relatedIdentifier>
+            <relatedIdentifier relatedIdentifierType="DOI" relationType="IsVersionOf">10.5281/zenodo.2573505</relatedIdentifier>
+          </relatedIdentifiers>
+          <version>0.12.1</version>
+          <rightsList>
+            <rights rightsURI="info:eu-repo/semantics/openAccess">Open Access</rights>
+          </rightsList>
+          <descriptions>
+            <description descriptionType="Abstract">Changed
+&lt;ul&gt;
+&lt;li&gt;Increased the &lt;code&gt;qiskit-ibmq-provider&lt;/code&gt; version to the latest release 0.3.3.&lt;/li&gt;
+&lt;/ul&gt;</description>
+          </descriptions>
+        </resource>
+      </metadata>
+    </record>

--- a/tests/stubdata/input/zenodo_test3.xml
+++ b/tests/stubdata/input/zenodo_test3.xml
@@ -1,0 +1,169 @@
+<record>
+      <header>
+        <identifier>oai:zenodo.org:1000003</identifier>
+        <datestamp>2023-08-10T11:59:20Z</datestamp>
+        <setSpec>software</setSpec>
+      </header>
+      <metadata>
+        <resource xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
+          <identifier identifierType="DOI">10.5281/zenodo.1000003</identifier>
+          <creators>
+            <creator>
+              <creatorName>Casper da Costa-Luis</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Stephen L.</creatorName>
+              <affiliation>Coma Science Group</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Hadrien Mary</creatorName>
+              <affiliation>University of McGill</affiliation>
+            </creator>
+            <creator>
+              <creatorName>noamraph</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Mikhail Korobov</creatorName>
+              <affiliation>@ScrapingHub</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Ivan Ivanov</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>James</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Matthew D. Pagel</creatorName>
+              <affiliation>UC Davis</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Socialery</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Jack McCracken</creatorName>
+              <affiliation>@Shopify</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Fabian Dill</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Daniel Panteleit</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Alex Rothberg</creatorName>
+              <affiliation>4Catalyzer</affiliation>
+            </creator>
+            <creator>
+              <creatorName>zed</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Riccardo Coccioli</creatorName>
+              <affiliation>Wikimedia Foundation</affiliation>
+            </creator>
+            <creator>
+              <creatorName>elsonidoq</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>deeenes</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Albert Kottke</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Yaroslav Halchenko</creatorName>
+              <affiliation>Dartmouth College, @Debian, @DataLad, @PyMVPA, @fail2ban</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Tomas Ostasevicius</creatorName>
+              <affiliation>University of Cambridge</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Shirish Pokharel</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>ReadmeCritic</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Peter VandeHaar</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Kuang-che Wu</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>jcea</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Hugo</creatorName>
+              <affiliation>Nord Software</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Ford Hurley</creatorName>
+              <affiliation>@handwritingio</affiliation>
+            </creator>
+            <creator>
+              <creatorName>Arun Persaud</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Alexander</creatorName>
+              <affiliation></affiliation>
+            </creator>
+            <creator>
+              <creatorName>Adnan Umer</creatorName>
+              <affiliation>@arbisoft</affiliation>
+            </creator>
+          </creators>
+          <titles>
+            <title>tqdm/tqdm: tqdm v4.18.0 stable</title>
+          </titles>
+          <publisher>Zenodo</publisher>
+          <publicationYear>2017</publicationYear>
+          <dates>
+            <date dateType="Issued">2017-09-30</date>
+          </dates>
+          <resourceType resourceTypeGeneral="Software"/>
+          <relatedIdentifiers>
+            <relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementTo">https://github.com/tqdm/tqdm/tree/v4.18.0</relatedIdentifier>
+            <relatedIdentifier relatedIdentifierType="DOI" relationType="IsVersionOf">10.5281/zenodo.595120</relatedIdentifier>
+          </relatedIdentifiers>
+          <version>v4.18.0</version>
+          <rightsList>
+            <rights rightsURI="info:eu-repo/semantics/openAccess">Open Access</rights>
+          </rightsList>
+          <descriptions>
+            <description descriptionType="Abstract">&lt;ul&gt;
+&lt;li&gt;Thread safety! (#285 -&amp;gt; #291 -&amp;gt; #329, #407, #417)&lt;/li&gt;
+&lt;li&gt;Ease redirection of &lt;code&gt;sys.stdout&lt;/code&gt;/&lt;code&gt;stderr&lt;/code&gt; (#422)&lt;/li&gt;
+&lt;li&gt;Minor internal stream bugfix (#439)&lt;/li&gt;
+&lt;li&gt;&lt;code&gt;AttributeError&lt;/code&gt; fixes (#323, #324, #418)&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;Related to:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Misc bugs (#334)&lt;/li&gt;
+&lt;li&gt;&lt;code&gt;concurrent.futures&lt;/code&gt; (#97)&lt;/li&gt;
+&lt;li&gt;Multi-&lt;code&gt;tqdm&lt;/code&gt; (#143)&lt;/li&gt;
+&lt;li&gt;&lt;code&gt;flush()&lt;/code&gt; and &lt;code&gt;refresh()&lt;/code&gt; (#331)&lt;/li&gt;
+&lt;li&gt;Newline on &lt;code&gt;refresh()&lt;/code&gt; (#361)&lt;/li&gt;
+&lt;li&gt;Nested trees (#384)&lt;/li&gt;
+&lt;li&gt;Manually positioned nested bars clearing (#385)&lt;/li&gt;
+&lt;/ul&gt;</description>
+          </descriptions>
+        </resource>
+      </metadata>
+    </record>

--- a/tests/stubdata/input/zenodo_test4.xml
+++ b/tests/stubdata/input/zenodo_test4.xml
@@ -1,0 +1,76 @@
+<record>
+      <header>
+        <identifier>oai:zenodo.org:7757685</identifier>
+        <datestamp>2023-07-06T23:58:10Z</datestamp>
+        <setSpec>software</setSpec>
+        <setSpec>user-aas</setSpec>
+        <setSpec>user-astronomy-general</setSpec>
+      </header>
+      <metadata>
+        <resource xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
+          <identifier identifierType="DOI">10.5281/zenodo.7757685</identifier>
+          <creators>
+            <creator>
+              <creatorName>Oliver Newton</creatorName>
+              <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="http://orcid.org/">0000-0002-2769-9507</nameIdentifier>
+              <affiliation>Center for Theoretical Physics, Polish Academy of Sciences</affiliation>
+            </creator>
+          </creators>
+          <titles>
+            <title>HESTIA Local Group field UDG paper scripts &amp; reduced data</title>
+          </titles>
+          <publisher>Zenodo</publisher>
+          <publicationYear>2023</publicationYear>
+          <subjects>
+            <subject>Ultra-diffuse galaxies</subject>
+            <subject>Milky Way</subject>
+            <subject>Andromeda</subject>
+            <subject>Local Group</subject>
+            <subject>HESTIA</subject>
+            <subject>Python</subject>
+          </subjects>
+          <dates>
+            <date dateType="Issued">2023-03-21</date>
+          </dates>
+          <language>en</language>
+          <resourceType resourceTypeGeneral="Software"/>
+          <relatedIdentifiers>
+            <relatedIdentifier relatedIdentifierType="URL" relationType="IsSupplementTo">https://github.com/Musical-Neutron/lg_field_udgs/tree/v1.1</relatedIdentifier>
+            <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementTo" resourceTypeGeneral="Preprint">10.48550/arXiv.2212.05066</relatedIdentifier>
+            <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementTo" resourceTypeGeneral="JournalArticle">10.3847/2041-8213/acc2bb</relatedIdentifier>
+            <relatedIdentifier relatedIdentifierType="DOI" relationType="Cites" resourceTypeGeneral="JournalArticle">10.1093/mnras/staa375</relatedIdentifier>
+            <relatedIdentifier relatedIdentifierType="DOI" relationType="Cites" resourceTypeGeneral="JournalArticle">10.1088/0004-6256/144/1/4</relatedIdentifier>
+            <relatedIdentifier relatedIdentifierType="DOI" relationType="Cites" resourceTypeGeneral="JournalArticle">10.3847/1538-4357/ac91cb</relatedIdentifier>
+            <relatedIdentifier relatedIdentifierType="DOI" relationType="Cites" resourceTypeGeneral="JournalArticle">10.1086/589911</relatedIdentifier>
+            <relatedIdentifier relatedIdentifierType="DOI" relationType="IsVersionOf">10.5281/zenodo.7729995</relatedIdentifier>
+            <relatedIdentifier relatedIdentifierType="URL" relationType="IsPartOf">https://zenodo.org/communities/aas</relatedIdentifier>
+            <relatedIdentifier relatedIdentifierType="URL" relationType="IsPartOf">https://zenodo.org/communities/astronomy-general</relatedIdentifier>
+          </relatedIdentifiers>
+          <version>v1.1</version>
+          <rightsList>
+            <rights rightsURI="https://opensource.org/licenses/AGPL-3.0">GNU Affero General Public License v3.0</rights>
+            <rights rightsURI="info:eu-repo/semantics/openAccess">Open Access</rights>
+          </rightsList>
+          <descriptions>
+            <description descriptionType="Abstract">&lt;p&gt;The final release of the supporting data and scripts to reproduce the figures in &lt;a href="https://doi.org/10.3847/2041-8213/acc2bb"&gt;O. Newton et al. (2023)&lt;/a&gt;. This &lt;em&gt;Letter&lt;/em&gt; appears in The Astrophysical Journal Letters.&lt;/p&gt;
+
+&lt;p&gt;A full description of the files and data contained in this repository is provided in the README file.&lt;/p&gt;
+
+&lt;p&gt;What&amp;#39;s Changed&lt;/p&gt;
+
+&lt;ul&gt;
+	&lt;li&gt;Bump contourpy from 1.0.6 to 1.0.7 by @dependabot in &lt;a href="https://github.com/Musical-Neutron/lg_field_udgs/pull/16"&gt;https://github.com/Musical-Neutron/lg_field_udgs/pull/16&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;Bump h5py from 3.7.0 to 3.8.0 by @dependabot in &lt;a href="https://github.com/Musical-Neutron/lg_field_udgs/pull/17"&gt;https://github.com/Musical-Neutron/lg_field_udgs/pull/17&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;Bump fonttools from 4.38.0 to 4.39.2 by @dependabot in &lt;a href="https://github.com/Musical-Neutron/lg_field_udgs/pull/18"&gt;https://github.com/Musical-Neutron/lg_field_udgs/pull/18&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;Fixing matplotlib warnings raised when running fig_04_plot_luminosity_functions.py and fig_05_plot_mock_sdss_observations.py&lt;/li&gt;
+	&lt;li&gt;Adding ApJL DOIs to README&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;&lt;strong&gt;Full Changelog&lt;/strong&gt;: &lt;a href="https://github.com/Musical-Neutron/lg_field_udgs/compare/v1.0...v1.1"&gt;https://github.com/Musical-Neutron/lg_field_udgs/compare/v1.0...v1.1&lt;/a&gt;&lt;/p&gt;</description>
+            <description descriptionType="Other">Additional funding acknowledgements
+Project IDEX-LYON (ANR-16-IDEX-0005) 
+Polish National Science Centre (2020/39/B/ST9/03494)</description>
+          </descriptions>
+        </resource>
+      </metadata>
+    </record>

--- a/tests/stubdata/input/zenodo_test4.xml
+++ b/tests/stubdata/input/zenodo_test4.xml
@@ -68,7 +68,7 @@
 
 &lt;p&gt;&lt;strong&gt;Full Changelog&lt;/strong&gt;: &lt;a href="https://github.com/Musical-Neutron/lg_field_udgs/compare/v1.0...v1.1"&gt;https://github.com/Musical-Neutron/lg_field_udgs/compare/v1.0...v1.1&lt;/a&gt;&lt;/p&gt;</description>
             <description descriptionType="Other">Additional funding acknowledgements
-Project IDEX-LYON (ANR-16-IDEX-0005) 
+Project IDEX-LYON (ANR-16-IDEX-0005)
 Polish National Science Centre (2020/39/B/ST9/03494)</description>
           </descriptions>
         </resource>

--- a/tests/stubdata/output/datacite_schema3.1_example-full.json
+++ b/tests/stubdata/output/datacite_schema3.1_example-full.json
@@ -93,5 +93,10 @@
       "keyString": "000 computer science",
       "keySystem": "datacite"
     }
-  ]
+  ],
+  "openAccess": {
+    "open": true,
+    "license": "CC0 1.0 Universal",
+    "licenseURL": "http://creativecommons.org/publicdomain/zero/1.0/"
+  }
 }

--- a/tests/stubdata/output/datacite_schema4.1_example-full.json
+++ b/tests/stubdata/output/datacite_schema4.1_example-full.json
@@ -91,5 +91,10 @@
       "keyString": "000 computer science",
       "keySystem": "datacite"
     }
-  ]
+  ],
+  "openAccess": {
+    "open": true,
+    "license": "CC0 1.0 Universal",
+    "licenseURL": "http://creativecommons.org/publicdomain/zero/1.0/"
+  }
 }

--- a/tests/stubdata/output/datacite_schema4.1_example-software.json
+++ b/tests/stubdata/output/datacite_schema4.1_example-software.json
@@ -1,33 +1,147 @@
-{"abstract": {"textEnglish": "Set of scripts used to process direct infusion mass spectrometry data as described in the associated paper"},
- "authors": [{"attrib": {"orcid": "0000-0002-2997-2175"}, "name": {"given_name": "AT", "pubraw": "Zielinski, AT", "surname": "Zielinski"}},
-             {"name": {"given_name": "M", "pubraw": "Kalberer, M", "surname": "Kalberer"}},
-             {"name": {"given_name": "C", "pubraw": "Bortolini, C", "surname": "Bortolini"}},
-             {"name": {"given_name": "C", "pubraw": "Giorio, C", "surname": "Giorio"}},
-             {"name": {"given_name": "SJ", "pubraw": "Fuller, SJ", "surname": "Fuller"}},
-             {"name": {"given_name": "I", "pubraw": "Kourtchev, I", "surname": "Kourtchev"}},
-             {"name": {"given_name": "O", "pubraw": "Popoola, O", "surname": "Popoola"}}],
- "doctype": "software",
- "keywords": [{"keyString": "UHRMS", "keySystem": "datacite"},
-              {"keyString": "ESI", "keySystem": "datacite"},
-              {"keyString": "APPI", "keySystem": "datacite"},
-              {"keyString": "Environmental samples", "keySystem": "datacite"},
-              {"keyString": "direct infusion", "keySystem": "datacite"},
-              {"keyString": "Orbitrap", "keySystem": "datacite"}],
- "otherContributor": [{"contrib": {"name": {"given_name": "Apollo",
-                                            "middle_name": "- University of",
-                                            "pubraw": "Apollo - University of Cambridge Repository",
-                                            "surname": "Cambridge Repository"}},
-                       "role": "HostingInstitution"}],
- "persistentIDs": [{"DOI": "10.5072/example-software-2.0"}],
- "pubDate": {"electrDate": "2017",
-             "otherDate": [{"otherDateType": "Issued", "otherDateValue": "2017-05-08"}, {"otherDateType": "Available", "otherDateValue": "2017-05-08"}]},
- "publication": {"pubYear": "2017", "publisher": "Apollo - University of Cambridge Repository"},
- "recordData": {"createdTime": "",
-                "loadFormat": "OtherXML",
-                "loadLocation": "",
-                "loadType": "fromFile",
-                "parsedTime": "",
-                "recordOrigin": ""},
- "relatedTo": [{"relatedDocID": "doi:10.5072/example-software-1.0", "relationship": "updated"},
-               {"relatedDocID": "doi:10.5072/example-software-repository", "relationship": "related"}],
- "title": {"textEnglish": "Code supporting \"A new processing scheme for ultra-high resolution direct infusion mass spectrometry data\""}}
+{
+  "recordData": {
+    "createdTime": "",
+    "parsedTime": "",
+    "loadType": "fromFile",
+    "loadFormat": "OtherXML",
+    "loadLocation": "",
+    "recordOrigin": ""
+  },
+  "relatedTo": [
+    {
+      "relationship": "updated",
+      "relatedDocID": "doi:10.5072/example-software-1.0"
+    },
+    {
+      "relationship": "related",
+      "relatedDocID": "doi:10.5072/example-software-repository"
+    }
+  ],
+  "pubDate": {
+    "electrDate": "2017",
+    "otherDate": [
+      {
+        "otherDateType": "Issued",
+        "otherDateValue": "2017-05-08"
+      },
+      {
+        "otherDateType": "Available",
+        "otherDateValue": "2017-05-08"
+      }
+    ]
+  },
+  "publication": {
+    "publisher": "Apollo - University of Cambridge Repository",
+    "pubYear": "2017"
+  },
+  "persistentIDs": [
+    {
+      "DOI": "10.5072/example-software-2.0"
+    }
+  ],
+  "authors": [
+    {
+      "name": {
+        "surname": "Zielinski",
+        "given_name": "AT",
+        "pubraw": "Zielinski, AT"
+      },
+      "attrib": {
+        "orcid": "0000-0002-2997-2175"
+      }
+    },
+    {
+      "name": {
+        "surname": "Kalberer",
+        "given_name": "M",
+        "pubraw": "Kalberer, M"
+      }
+    },
+    {
+      "name": {
+        "surname": "Bortolini",
+        "given_name": "C",
+        "pubraw": "Bortolini, C"
+      }
+    },
+    {
+      "name": {
+        "surname": "Giorio",
+        "given_name": "C",
+        "pubraw": "Giorio, C"
+      }
+    },
+    {
+      "name": {
+        "surname": "Fuller",
+        "given_name": "SJ",
+        "pubraw": "Fuller, SJ"
+      }
+    },
+    {
+      "name": {
+        "surname": "Kourtchev",
+        "given_name": "I",
+        "pubraw": "Kourtchev, I"
+      }
+    },
+    {
+      "name": {
+        "surname": "Popoola",
+        "given_name": "O",
+        "pubraw": "Popoola, O"
+      }
+    }
+  ],
+  "otherContributor": [
+    {
+      "role": "HostingInstitution",
+      "contrib": {
+        "name": {
+          "surname": "Cambridge Repository",
+          "given_name": "Apollo",
+          "middle_name": "- University of",
+          "pubraw": "Apollo - University of Cambridge Repository"
+        }
+      }
+    }
+  ],
+  "title": {
+    "textEnglish": "Code supporting \"A new processing scheme for ultra-high resolution direct infusion mass spectrometry data\""
+  },
+  "abstract": {
+    "textEnglish": "Set of scripts used to process direct infusion mass spectrometry data as described in the associated paper"
+  },
+  "doctype": "software",
+  "keywords": [
+    {
+      "keyString": "UHRMS",
+      "keySystem": "datacite"
+    },
+    {
+      "keyString": "ESI",
+      "keySystem": "datacite"
+    },
+    {
+      "keyString": "APPI",
+      "keySystem": "datacite"
+    },
+    {
+      "keyString": "Environmental samples",
+      "keySystem": "datacite"
+    },
+    {
+      "keyString": "direct infusion",
+      "keySystem": "datacite"
+    },
+    {
+      "keyString": "Orbitrap",
+      "keySystem": "datacite"
+    }
+  ],
+  "openAccess": {
+    "open": true,
+    "license": "GNU General Public License version 3",
+    "licenseURL": "https://opensource.org/licenses/GPL-3.0"
+  }
+}

--- a/tests/stubdata/output/datacite_schema4_example-habanero-pdsdataset.json
+++ b/tests/stubdata/output/datacite_schema4_example-habanero-pdsdataset.json
@@ -96,9 +96,9 @@
   "doctype": "misc",
   "keywords": [
     {
-      "keyID": "72",
       "keyString": "Asteroids",
-      "keySystem": "UAT"
+      "keySystem": "UAT",
+      "keyID": "72"
     }
   ]
 }

--- a/tests/stubdata/output/zenodo_test.json
+++ b/tests/stubdata/output/zenodo_test.json
@@ -1,0 +1,74 @@
+{
+  "recordData": {
+    "createdTime": "",
+    "parsedTime": "",
+    "loadType": "fromFile",
+    "loadFormat": "OtherXML",
+    "loadLocation": "",
+    "recordOrigin": ""
+  },
+  "relatedTo": [
+    {
+      "relationship": "related"
+    },
+    {
+      "relationship": "related",
+      "relatedDocID": "https://zenodo.org/communities/sciops2015"
+    }
+  ],
+  "pubDate": {
+    "electrDate": "2015",
+    "otherDate": [
+      {
+        "otherDateType": "Issued",
+        "otherDateValue": "2015-12-03"
+      }
+    ]
+  },
+  "publication": {
+    "publisher": "Zenodo",
+    "pubYear": "2015"
+  },
+  "persistentIDs": [
+    {
+      "DOI": "10.5281/zenodo.34650"
+    }
+  ],
+  "publisherIDs": [
+    {
+      "attribute": "oai",
+      "Identifier": "oai:zenodo.org:34650"
+    }
+  ],
+  "authors": [
+    {
+      "name": {
+        "surname": "Reetz",
+        "given_name": "Johannes"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "Max Planck Computing and Data Facility, Garching, Germany"
+        }
+      ]
+    }
+  ],
+  "title": {
+    "textEnglish": "EUDAT - Open Data Services for Research"
+  },
+  "abstract": {
+    "textEnglish": "Presentation slides"
+  },
+  "doctype": "misc",
+  "keywords": [
+    {
+      "keyString": "Science data management",
+      "keySystem": "datacite"
+    }
+  ],
+  "openAccess": {
+    "open": true,
+    "license": "Creative Commons Attribution 4.0 International",
+    "licenseURL": "https://creativecommons.org/licenses/by/4.0/legalcode"
+  }
+}

--- a/tests/stubdata/output/zenodo_test2.json
+++ b/tests/stubdata/output/zenodo_test2.json
@@ -1,0 +1,349 @@
+{
+  "recordData": {
+    "createdTime": "",
+    "parsedTime": "",
+    "loadType": "fromFile",
+    "loadFormat": "OtherXML",
+    "loadLocation": "",
+    "recordOrigin": ""
+  },
+  "relatedTo": [
+    {
+      "relationship": "supplement",
+      "relatedDocID": "https://github.com/Qiskit/qiskit/tree/0.12.1"
+    },
+    {
+      "relationship": "related",
+      "relatedDocID": "10.5281/zenodo.2573505"
+    }
+  ],
+  "pubDate": {
+    "electrDate": "2019",
+    "otherDate": [
+      {
+        "otherDateType": "Issued",
+        "otherDateValue": "2019-09-30"
+      }
+    ]
+  },
+  "publication": {
+    "publisher": "Zenodo",
+    "pubYear": "2019"
+  },
+  "persistentIDs": [
+    {
+      "DOI": "10.5281/zenodo.3465853"
+    }
+  ],
+  "authors": [
+    {
+      "name": {
+        "surname": "Gambetta",
+        "given_name": "Jay",
+        "pubraw": "Jay Gambetta"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "@IBM"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Treinish",
+        "given_name": "Matthew",
+        "pubraw": "Matthew Treinish"
+      }
+    },
+    {
+      "name": {
+        "surname": "Kassebaum",
+        "given_name": "Paul",
+        "pubraw": "Paul Kassebaum"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "IBM"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Rodr\u00edguez",
+        "given_name": "Diego",
+        "middle_name": "M.",
+        "pubraw": "Diego M. Rodr\u00edguez"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "@IBMResearch"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "de la Puente Gonz\u00e1lez",
+        "given_name": "Salvador",
+        "pubraw": "Salvador de la Puente Gonz\u00e1lez"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "@IBMResearch"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Nation",
+        "given_name": "Paul",
+        "pubraw": "Paul Nation"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "IBM"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Hu",
+        "given_name": "Shaohan",
+        "pubraw": "Shaohan Hu"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "IBM Research"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Zdanski",
+        "given_name": "Laura",
+        "pubraw": "Laura Zdanski"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "@IBM @openliberty"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Pistoia",
+        "given_name": "Marco",
+        "pubraw": "Marco Pistoia"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "IBM"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Krsulich",
+        "given_name": "Kevin",
+        "pubraw": "Kevin Krsulich"
+      }
+    },
+    {
+      "name": {
+        "given_name": "Travis-S-IBM",
+        "pubraw": "Travis-S-IBM"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "IBM"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Gomez",
+        "given_name": "Juan",
+        "pubraw": "Juan Gomez"
+      }
+    },
+    {
+      "name": {
+        "surname": "McKay",
+        "given_name": "David",
+        "pubraw": "David McKay"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "@IBM, @Qiskit"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Frisch",
+        "given_name": "Albert",
+        "pubraw": "Albert Frisch"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "IBM @QISKit"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Naveh",
+        "given_name": "Yehuda",
+        "pubraw": "Yehuda Naveh"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "IBM Research"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Wood",
+        "given_name": "Steve",
+        "pubraw": "Steve Wood"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "IBM Research"
+        }
+      ]
+    },
+    {
+      "name": {
+        "given_name": "Zoufalc",
+        "pubraw": "Zoufalc"
+      }
+    },
+    {
+      "name": {
+        "given_name": "tigerjack",
+        "pubraw": "tigerjack"
+      }
+    },
+    {
+      "name": {
+        "surname": "Garion",
+        "given_name": "Shelly",
+        "pubraw": "Shelly Garion"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "IBM"
+        }
+      ]
+    },
+    {
+      "name": {
+        "given_name": "RohitMidha23",
+        "pubraw": "RohitMidha23"
+      }
+    },
+    {
+      "name": {
+        "given_name": "KaoriNamba",
+        "pubraw": "KaoriNamba"
+      }
+    },
+    {
+      "name": {
+        "surname": "Cruz-Benito",
+        "given_name": "Juan",
+        "pubraw": "Juan Cruz-Benito"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "@IBMResearch"
+        }
+      ]
+    },
+    {
+      "name": {
+        "given_name": "HNorlen",
+        "pubraw": "HNorlen"
+      }
+    },
+    {
+      "name": {
+        "surname": "Varchon",
+        "given_name": "Francois",
+        "pubraw": "Francois Varchon"
+      }
+    },
+    {
+      "name": {
+        "surname": "Wood",
+        "given_name": "Christopher",
+        "middle_name": "J.",
+        "pubraw": "Christopher J. Wood"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "IBM Research @QISKit"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Osvaldo Gonzalez Aceves",
+        "given_name": "Blas",
+        "pubraw": "Blas Osvaldo Gonzalez Aceves"
+      }
+    },
+    {
+      "name": {
+        "surname": "Rodriguez",
+        "given_name": "Baltazar",
+        "pubraw": "Baltazar Rodriguez"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "IBM"
+        }
+      ]
+    },
+    {
+      "name": {
+        "given_name": "Ayumu-walker",
+        "pubraw": "Ayumu-walker"
+      }
+    },
+    {
+      "name": {
+        "surname": "Amano",
+        "given_name": "Takehiko"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "IBM"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Pozas-Kerstjens",
+        "given_name": "Alex",
+        "pubraw": "Alex Pozas-Kerstjens"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "ICFO"
+        }
+      ]
+    }
+  ],
+  "title": {
+    "textEnglish": "Qiskit/qiskit: Qiskit 0.12.1"
+  },
+  "abstract": {
+    "textEnglish": "Changed Increased the qiskit-ibmq-provider version to the latest release 0.3.3."
+  },
+  "doctype": "software",
+  "openAccess": {
+    "open": true
+  }
+}

--- a/tests/stubdata/output/zenodo_test3.json
+++ b/tests/stubdata/output/zenodo_test3.json
@@ -1,0 +1,311 @@
+{
+  "recordData": {
+    "createdTime": "",
+    "parsedTime": "",
+    "loadType": "fromFile",
+    "loadFormat": "OtherXML",
+    "loadLocation": "",
+    "recordOrigin": ""
+  },
+  "relatedTo": [
+    {
+      "relationship": "supplement",
+      "relatedDocID": "https://github.com/tqdm/tqdm/tree/v4.18.0"
+    },
+    {
+      "relationship": "related",
+      "relatedDocID": "10.5281/zenodo.595120"
+    }
+  ],
+  "pubDate": {
+    "electrDate": "2017",
+    "otherDate": [
+      {
+        "otherDateType": "Issued",
+        "otherDateValue": "2017-09-30"
+      }
+    ]
+  },
+  "publication": {
+    "publisher": "Zenodo",
+    "pubYear": "2017"
+  },
+  "persistentIDs": [
+    {
+      "DOI": "10.5281/zenodo.1000003"
+    }
+  ],
+  "authors": [
+    {
+      "name": {
+        "surname": "da Costa-Luis",
+        "given_name": "Casper",
+        "pubraw": "Casper da Costa-Luis"
+      }
+    },
+    {
+      "name": {
+        "surname": "L.",
+        "given_name": "Stephen",
+        "pubraw": "Stephen L."
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "Coma Science Group"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Mary",
+        "given_name": "Hadrien",
+        "pubraw": "Hadrien Mary"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "University of McGill"
+        }
+      ]
+    },
+    {
+      "name": {
+        "given_name": "noamraph",
+        "pubraw": "noamraph"
+      }
+    },
+    {
+      "name": {
+        "surname": "Korobov",
+        "given_name": "Mikhail",
+        "pubraw": "Mikhail Korobov"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "@ScrapingHub"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Ivanov",
+        "given_name": "Ivan",
+        "pubraw": "Ivan Ivanov"
+      }
+    },
+    {
+      "name": {
+        "given_name": "James",
+        "pubraw": "James"
+      }
+    },
+    {
+      "name": {
+        "surname": "Pagel",
+        "given_name": "Matthew",
+        "middle_name": "D.",
+        "pubraw": "Matthew D. Pagel"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "UC Davis"
+        }
+      ]
+    },
+    {
+      "name": {
+        "given_name": "Socialery",
+        "pubraw": "Socialery"
+      }
+    },
+    {
+      "name": {
+        "surname": "McCracken",
+        "given_name": "Jack",
+        "pubraw": "Jack McCracken"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "@Shopify"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Dill",
+        "given_name": "Fabian",
+        "pubraw": "Fabian Dill"
+      }
+    },
+    {
+      "name": {
+        "surname": "Panteleit",
+        "given_name": "Daniel",
+        "pubraw": "Daniel Panteleit"
+      }
+    },
+    {
+      "name": {
+        "surname": "Rothberg",
+        "given_name": "Alex",
+        "pubraw": "Alex Rothberg"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "4Catalyzer"
+        }
+      ]
+    },
+    {
+      "name": {
+        "given_name": "zed",
+        "pubraw": "zed"
+      }
+    },
+    {
+      "name": {
+        "surname": "Coccioli",
+        "given_name": "Riccardo",
+        "pubraw": "Riccardo Coccioli"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "Wikimedia Foundation"
+        }
+      ]
+    },
+    {
+      "name": {
+        "given_name": "elsonidoq",
+        "pubraw": "elsonidoq"
+      }
+    },
+    {
+      "name": {
+        "given_name": "deeenes",
+        "pubraw": "deeenes"
+      }
+    },
+    {
+      "name": {
+        "surname": "Kottke",
+        "given_name": "Albert",
+        "pubraw": "Albert Kottke"
+      }
+    },
+    {
+      "name": {
+        "surname": "Halchenko",
+        "given_name": "Yaroslav",
+        "pubraw": "Yaroslav Halchenko"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "Dartmouth College, @Debian, @DataLad, @PyMVPA, @fail2ban"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Ostasevicius",
+        "given_name": "Tomas",
+        "pubraw": "Tomas Ostasevicius"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "University of Cambridge"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Pokharel",
+        "given_name": "Shirish",
+        "pubraw": "Shirish Pokharel"
+      }
+    },
+    {
+      "name": {
+        "given_name": "ReadmeCritic",
+        "pubraw": "ReadmeCritic"
+      }
+    },
+    {
+      "name": {
+        "surname": "VandeHaar",
+        "given_name": "Peter",
+        "pubraw": "Peter VandeHaar"
+      }
+    },
+    {
+      "name": {
+        "surname": "Wu",
+        "given_name": "Kuang-che",
+        "pubraw": "Kuang-che Wu"
+      }
+    },
+    {
+      "name": {
+        "given_name": "jcea",
+        "pubraw": "jcea"
+      }
+    },
+    {
+      "name": {
+        "given_name": "Hugo",
+        "pubraw": "Hugo"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "Nord Software"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Hurley",
+        "given_name": "Ford",
+        "pubraw": "Ford Hurley"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "@handwritingio"
+        }
+      ]
+    },
+    {
+      "name": {
+        "surname": "Persaud",
+        "given_name": "Arun",
+        "pubraw": "Arun Persaud"
+      }
+    },
+    {
+      "name": {
+        "given_name": "Alexander",
+        "pubraw": "Alexander"
+      }
+    },
+    {
+      "name": {
+        "surname": "Umer",
+        "given_name": "Adnan",
+        "pubraw": "Adnan Umer"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "@arbisoft"
+        }
+      ]
+    }
+  ],
+  "title": {
+    "textEnglish": "tqdm/tqdm: tqdm v4.18.0 stable"
+  },
+  "abstract": {
+    "textEnglish": "Thread safety! (#285 -> #291 -> #329, #407, #417) Ease redirection of sys.stdout/stderr (#422) Minor internal stream bugfix (#439) AttributeError fixes (#323, #324, #418) Related to: Misc bugs (#334) concurrent.futures (#97) Multi-tqdm (#143) flush() and refresh() (#331) Newline on refresh() (#361) Nested trees (#384) Manually positioned nested bars clearing (#385)"
+  },
+  "doctype": "software",
+  "openAccess": {
+    "open": true
+  }
+}

--- a/tests/stubdata/output/zenodo_test4.json
+++ b/tests/stubdata/output/zenodo_test4.json
@@ -1,0 +1,115 @@
+{
+  "recordData": {
+    "createdTime": "",
+    "parsedTime": "",
+    "loadType": "fromFile",
+    "loadFormat": "OtherXML",
+    "loadLocation": "",
+    "recordOrigin": ""
+  },
+  "relatedTo": [
+    {
+      "relationship": "supplement",
+      "relatedDocID": "https://github.com/Musical-Neutron/lg_field_udgs/tree/v1.1"
+    },
+    {
+      "relationship": "supplement",
+      "relatedDocID": "10.48550/arXiv.2212.05066"
+    },
+    {
+      "relationship": "supplement",
+      "relatedDocID": "10.3847/2041-8213/acc2bb"
+    },
+    {
+      "relationship": "related",
+      "relatedDocID": "10.5281/zenodo.7729995"
+    },
+    {
+      "relationship": "related",
+      "relatedDocID": "https://zenodo.org/communities/aas"
+    },
+    {
+      "relationship": "related",
+      "relatedDocID": "https://zenodo.org/communities/astronomy-general"
+    }
+  ],
+  "pubDate": {
+    "electrDate": "2023",
+    "otherDate": [
+      {
+        "otherDateType": "Issued",
+        "otherDateValue": "2023-03-21"
+      }
+    ]
+  },
+  "publication": {
+    "publisher": "Zenodo",
+    "pubYear": "2023"
+  },
+  "persistentIDs": [
+    {
+      "DOI": "10.5281/zenodo.7757685"
+    }
+  ],
+  "authors": [
+    {
+      "name": {
+        "surname": "Newton",
+        "given_name": "Oliver",
+        "pubraw": "Oliver Newton"
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "Center for Theoretical Physics, Polish Academy of Sciences"
+        }
+      ],
+      "attrib": {
+        "orcid": "0000-0002-2769-9507"
+      }
+    }
+  ],
+  "title": {
+    "textEnglish": "HESTIA Local Group field UDG paper scripts & reduced data"
+  },
+  "abstract": {
+    "textEnglish": "The final release of the supporting data and scripts to reproduce the figures in <a href=\"https://doi.org/10.3847/2041-8213/acc2bb\">O. Newton et al. (2023)</a>. This Letter appears in The Astrophysical Journal Letters. A full description of the files and data contained in this repository is provided in the README file. What's Changed Bump contourpy from 1.0.6 to 1.0.7 by @dependabot in <a href=\"https://github.com/Musical-Neutron/lg_field_udgs/pull/16\">https://github.com/Musical-Neutron/lg_field_udgs/pull/16</a> Bump h5py from 3.7.0 to 3.8.0 by @dependabot in <a href=\"https://github.com/Musical-Neutron/lg_field_udgs/pull/17\">https://github.com/Musical-Neutron/lg_field_udgs/pull/17</a> Bump fonttools from 4.38.0 to 4.39.2 by @dependabot in <a href=\"https://github.com/Musical-Neutron/lg_field_udgs/pull/18\">https://github.com/Musical-Neutron/lg_field_udgs/pull/18</a> Fixing matplotlib warnings raised when running fig_04_plot_luminosity_functions.py and fig_05_plot_mock_sdss_observations.py Adding ApJL DOIs to README Full Changelog: <a href=\"https://github.com/Musical-Neutron/lg_field_udgs/compare/v1.0...v1.1\">https://github.com/Musical-Neutron/lg_field_udgs/compare/v1.0...v1.1</a>"
+  },
+  "references": [
+    "10.1093/mnras/staa375",
+    "10.1088/0004-6256/144/1/4",
+    "10.3847/1538-4357/ac91cb",
+    "10.1086/589911"
+  ],
+  "doctype": "software",
+  "keywords": [
+    {
+      "keyString": "Ultra-diffuse galaxies",
+      "keySystem": "datacite"
+    },
+    {
+      "keyString": "Milky Way",
+      "keySystem": "datacite"
+    },
+    {
+      "keyString": "Andromeda",
+      "keySystem": "datacite"
+    },
+    {
+      "keyString": "Local Group",
+      "keySystem": "datacite"
+    },
+    {
+      "keyString": "HESTIA",
+      "keySystem": "datacite"
+    },
+    {
+      "keyString": "Python",
+      "keySystem": "datacite"
+    }
+  ],
+  "openAccess": {
+    "open": true,
+    "license": "GNU Affero General Public License v3.0",
+    "licenseURL": "https://opensource.org/licenses/AGPL-3.0"
+  }
+}

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,16 +4,16 @@ import pytest
 
 from adsingestp.parsers import base
 
+
 @pytest.mark.filterwarnings("ignore::bs4.MarkupResemblesLocatorWarning")
 class TestBase(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
 
     def test_basebs4(self):
-        data = "<bib xml:id=\"b54\"><citation type=\"journal\" xml:id=\"cit54\"><author><familyName>Kormendy</familyName> <givenNames>J.</givenNames></author>, <author><familyName>Richstone</familyName> <givenNames>D.</givenNames></author>, <pubYear year=\"1995\">1995</pubYear>, <journalTitle>ARA__amp__amp;A</journalTitle>, <vol>33</vol>, <pageFirst>581</pageFirst></citation></bib>"
+        data = '<bib xml:id="b54"><citation type="journal" xml:id="cit54"><author><familyName>Kormendy</familyName> <givenNames>J.</givenNames></author>, <author><familyName>Richstone</familyName> <givenNames>D.</givenNames></author>, <pubYear year="1995">1995</pubYear>, <journalTitle>ARA__amp__amp;A</journalTitle>, <vol>33</vol>, <pageFirst>581</pageFirst></citation></bib>'
 
         parser = base.BaseBeautifulSoupParser()
         record = parser._detag(data, parser.HTML_TAGS_HTML)
         record_corrected = "Kormendy J., Richstone D., 1995, ARA&amp;A, 33, 581"
         self.assertEqual(record, record_corrected)
-   

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,19 @@
+import unittest
+
+import pytest
+
+from adsingestp.parsers import base
+
+@pytest.mark.filterwarnings("ignore::bs4.MarkupResemblesLocatorWarning")
+class TestBase(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_basebs4(self):
+        data = "<bib xml:id=\"b54\"><citation type=\"journal\" xml:id=\"cit54\"><author><familyName>Kormendy</familyName> <givenNames>J.</givenNames></author>, <author><familyName>Richstone</familyName> <givenNames>D.</givenNames></author>, <pubYear year=\"1995\">1995</pubYear>, <journalTitle>ARA__amp__amp;A</journalTitle>, <vol>33</vol>, <pageFirst>581</pageFirst></citation></bib>"
+
+        parser = base.BaseBeautifulSoupParser()
+        record = parser._detag(data, parser.HTML_TAGS_HTML)
+        record_corrected = "Kormendy J., Richstone D., 1995, ARA&amp;A, 33, 581"
+        self.assertEqual(record, record_corrected)
+   

--- a/tests/test_datacite.py
+++ b/tests/test_datacite.py
@@ -24,6 +24,7 @@ class TestDatacite(unittest.TestCase):
         stubdata_dir = os.path.join(os.path.dirname(__file__), "stubdata/")
         self.inputdir = os.path.join(stubdata_dir, "input")
         self.outputdir = os.path.join(stubdata_dir, "output")
+        self.maxDiff = None
 
     def test_datacite(self):
         filenames = [
@@ -31,6 +32,10 @@ class TestDatacite(unittest.TestCase):
             "datacite_schema3.1_example-full",
             "datacite_schema4.1_example-software",
             "datacite_schema4_example-habanero-pdsdataset",
+            "zenodo_test",
+            "zenodo_test2",
+            "zenodo_test3",
+            "zenodo_test4",
         ]
         for f in filenames:
             test_infile = os.path.join(self.inputdir, f + ".xml")


### PR DESCRIPTION
…om JATSParser to BaseBeautifulSoupParser and renames tagsets from JATS_ to HTML_

 	modified:   adsingestp/parsers/base.py
 	modified:   adsingestp/parsers/datacite.py
 	modified:   adsingestp/parsers/jats.py
 	new file:   tests/stubdata/input/zenodo_test.xml
 	new file:   tests/stubdata/input/zenodo_test2.xml
 	new file:   tests/stubdata/input/zenodo_test3.xml
 	new file:   tests/stubdata/input/zenodo_test4.xml
 	modified:   tests/stubdata/output/datacite_schema3.1_example-full.json
 	modified:   tests/stubdata/output/datacite_schema4.1_example-full.json
 	modified:   tests/stubdata/output/datacite_schema4.1_example-software.json
 	modified:   tests/stubdata/output/datacite_schema4_example-habanero-pdsdataset.json
 	new file:   tests/stubdata/output/zenodo_test.json
 	new file:   tests/stubdata/output/zenodo_test2.json
 	new file:   tests/stubdata/output/zenodo_test3.json
 	new file:   tests/stubdata/output/zenodo_test4.json
 	modified:   tests/test_datacite.py