### PR TITLE
fix: copernicus electronic issn captured correctly

### DIFF
--- a/adsingestp/parsers/copernicus.py
+++ b/adsingestp/parsers/copernicus.py
@@ -58,7 +58,7 @@ class CopernicusParser(BaseBeautifulSoupParser):
             issns.append(("print", self.input_metadata.find("issn").get_text()))
 
         if self.input_metadata.find("eissn"):
-            issns.append(("electronic", self.input_metadata.find("issn").get_text()))
+            issns.append(("electronic", self.input_metadata.find("eissn").get_text()))
 
         self.base_metadata["issn"] = issns
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,9 @@ dev = [
     'semantic-release==0.1.0',
 ]
 docs = [
-    'Sphinx==4.3.1',
-    'myst-parser==0.15.2',
-    'sphinx-rtd-theme==1.0.0'
+    'Sphinx==7.6.2',
+    'myst-parser==2.0.0',
+    'sphinx-rtd-theme==2.0.0'
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
     'semantic-release==0.1.0',
 ]
 docs = [
-    'Sphinx==7.6.2',
+    'Sphinx==7.2.6',
     'myst-parser==2.0.0',
     'sphinx-rtd-theme==2.0.0'
 ]

--- a/tests/stubdata/output/copernicus_ESSD_essd-15-3075-2023.json
+++ b/tests/stubdata/output/copernicus_ESSD_essd-15-3075-2023.json
@@ -22,7 +22,7 @@
       },
       {
         "pubtype": "electronic",
-        "issnString": "1866-3508"
+        "issnString": "1866-3516"
       }
     ]
   },

--- a/tests/stubdata/output/copernicus_GeChr_gchron-5-323-2023.json
+++ b/tests/stubdata/output/copernicus_GeChr_gchron-5-323-2023.json
@@ -22,7 +22,7 @@
       },
       {
         "pubtype": "electronic",
-        "issnString": "2628-3697"
+        "issnString": "2628-3719"
       }
     ]
   },

--- a/tests/stubdata/output/copernicus_ISPAn_isprs-annals-X-M-1-2023-237-2023.json
+++ b/tests/stubdata/output/copernicus_ISPAn_isprs-annals-X-M-1-2023-237-2023.json
@@ -22,7 +22,7 @@
       },
       {
         "pubtype": "electronic",
-        "issnString": "2194-9042"
+        "issnString": "2194-9050"
       }
     ]
   },

--- a/tests/stubdata/output/copernicus_ISPAr_isprs-archives-XLVIII-M-2-2023-721-2023.json
+++ b/tests/stubdata/output/copernicus_ISPAr_isprs-archives-XLVIII-M-2-2023-721-2023.json
@@ -22,7 +22,7 @@
       },
       {
         "pubtype": "electronic",
-        "issnString": "1682-1750"
+        "issnString": "2194-9034"
       }
     ]
   },

--- a/tests/stubdata/output/copernicus_wes-8-1625-2023.json
+++ b/tests/stubdata/output/copernicus_wes-8-1625-2023.json
@@ -143,7 +143,7 @@
         "pubtype": "print"
       },
       {
-        "issnString": "2366-7443",
+        "issnString": "2366-7451",
         "pubtype": "electronic"
       }
     ],

--- a/tests/test_copernicus.py
+++ b/tests/test_copernicus.py
@@ -23,7 +23,6 @@ class TestCopernicus(unittest.TestCase):
         stubdata_dir = os.path.join(os.path.dirname(__file__), "stubdata/")
         self.inputdir = os.path.join(stubdata_dir, "input")
         self.outputdir = os.path.join(stubdata_dir, "output")
-        self.maxDiff = None
 
     def test_copernicus(self):
         filenames = [

--- a/tests/test_copernicus.py
+++ b/tests/test_copernicus.py
@@ -23,6 +23,7 @@ class TestCopernicus(unittest.TestCase):
         stubdata_dir = os.path.join(os.path.dirname(__file__), "stubdata/")
         self.inputdir = os.path.join(stubdata_dir, "input")
         self.outputdir = os.path.join(stubdata_dir, "output")
+        self.maxDiff = None
 
     def test_copernicus(self):
         filenames = [


### PR DESCRIPTION
 	modified:   adsingestp/parsers/copernicus.py
 	modified:   tests/stubdata/output/copernicus_ESSD_essd-15-3075-2023.json
 	modified:   tests/stubdata/output/copernicus_GeChr_gchron-5-323-2023.json
 	modified:   tests/stubdata/output/copernicus_ISPAn_isprs-annals-X-M-1-2023-237-2023.json
 	modified:   tests/stubdata/output/copernicus_ISPAr_isprs-archives-XLVIII-M-2-2023-721-2023.json
 	modified:   tests/stubdata/output/copernicus_wes-8-1625-2023.json
 	modified:   tests/test_copernicus.py
 	modified:   tests/stubdata/output/Copernicus_ESSD_essd-15-3075-2023.json
 	modified:   tests/stubdata/output/Copernicus_GeChr_gchron-5-323-2023.json
 	modified:   tests/stubdata/output/Copernicus_ISPAn_isprs-annals-X-M-1-2023-237-2023.json
 	modified:   tests/stubdata/output/Copernicus_ISPAr_isprs-archives-XLVIII-M-2-2023-721-2023.json