### PR TITLE
Xref affil.20240312

### DIFF
--- a/adsingestp/parsers/crossref.py
+++ b/adsingestp/parsers/crossref.py
@@ -265,6 +265,32 @@ class CrossrefParser(BaseBeautifulSoupParser):
                 affil = [a.get_text() for a in c.find_all("affiliation")]
                 if affil:
                     contrib_tmp["aff"] = affil
+            elif c.find("affiliations"):
+                print("YAY AFFILIATIONS")
+                affil = []
+                institutions = c.find("affiliations").find_all("institution")
+                if institutions:
+                    print("YAY INSTITUTIONS")
+                    for inst in institutions:
+                        print("YAY INST")
+                        name = inst.find("institution_name")
+                        dept = inst.find("institution_department")
+                        acro = inst.find("institution_acronym")
+                        place = inst.find("institution_place")
+                        ident = inst.find("institution_id")
+                        taglist = []
+                        if dept:
+                            taglist.append(dept.get_text())
+                        if name:
+                            taglist.append(name.get_text())
+                        if acro:
+                            taglist.append(acro.get_text())
+                        if place:
+                            taglist.append(place.get_text())
+                        if taglist:
+                            affil.append(", ".join(taglist))
+                if affil:
+                    contrib_tmp["aff"] = affil
 
             role = c.get("contributor_role", "unknown")
 

--- a/adsingestp/parsers/crossref.py
+++ b/adsingestp/parsers/crossref.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 # compile outside of the class definition -- it only needs to be compiled once
 re_issn = re.compile(r"^\d{4}-?\d{3}[0-9X]$")  # XXXX-XXXX
 
+
 class CrossrefParser(BaseBeautifulSoupParser):
     def __init__(self):
         self.base_metadata = {}
@@ -273,7 +274,6 @@ class CrossrefParser(BaseBeautifulSoupParser):
                         dept = inst.find("institution_department")
                         acro = inst.find("institution_acronym")
                         place = inst.find("institution_place")
-                        ident = inst.find("institution_id")
                         taglist = []
                         if dept:
                             taglist.append(dept.get_text())

--- a/adsingestp/parsers/crossref.py
+++ b/adsingestp/parsers/crossref.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 # compile outside of the class definition -- it only needs to be compiled once
 re_issn = re.compile(r"^\d{4}-?\d{3}[0-9X]$")  # XXXX-XXXX
 
-
 class CrossrefParser(BaseBeautifulSoupParser):
     def __init__(self):
         self.base_metadata = {}
@@ -266,13 +265,10 @@ class CrossrefParser(BaseBeautifulSoupParser):
                 if affil:
                     contrib_tmp["aff"] = affil
             elif c.find("affiliations"):
-                print("YAY AFFILIATIONS")
                 affil = []
                 institutions = c.find("affiliations").find_all("institution")
                 if institutions:
-                    print("YAY INSTITUTIONS")
                     for inst in institutions:
-                        print("YAY INST")
                         name = inst.find("institution_name")
                         dept = inst.find("institution_department")
                         acro = inst.find("institution_acronym")
@@ -288,7 +284,9 @@ class CrossrefParser(BaseBeautifulSoupParser):
                         if place:
                             taglist.append(place.get_text())
                         if taglist:
-                            affil.append(", ".join(taglist))
+                            affstring = ", ".join(taglist)
+                            affstring = re.sub(r"\s+,", ",", affstring)
+                            affil.append(affstring)
                 if affil:
                     contrib_tmp["aff"] = affil
 

--- a/tests/stubdata/output/crossref_cn_10.1093=mnras=stac2975.json
+++ b/tests/stubdata/output/crossref_cn_10.1093=mnras=stac2975.json
@@ -41,19 +41,37 @@
       "name": {
         "surname": "Yang",
         "given_name": "Haifeng"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ]
     },
     {
       "name": {
         "surname": "Shi",
         "given_name": "Chenhui"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ]
     },
     {
       "name": {
         "surname": "Cai",
         "given_name": "Jianghui"
       },
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        },
+        {
+          "affPubRaw": "School of Computer Science and Technology, North University of China, Taiyuan 030051, China"
+        }
+      ],
       "attrib": {
         "orcid": "0000-0001-6945-8093"
       }
@@ -62,31 +80,56 @@
       "name": {
         "surname": "Zhou",
         "given_name": "Lichan"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ]
     },
     {
       "name": {
         "surname": "Yang",
         "given_name": "Yuqing"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ]
     },
     {
       "name": {
         "surname": "Zhao",
         "given_name": "Xujun"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ]
     },
     {
       "name": {
         "surname": "He",
         "given_name": "Yanting"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ]
     },
     {
       "name": {
         "surname": "Hao",
         "given_name": "Jing"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ]
     }
   ],
   "title": {

--- a/tests/stubdata/output/crossref_cn_10.1093=pasj=psac053.json
+++ b/tests/stubdata/output/crossref_cn_10.1093=pasj=psac053.json
@@ -42,6 +42,11 @@
         "surname": "Shimoda",
         "given_name": "Jiro"
       },
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, Graduate School of Science, Nagoya University, Furo-cho, Chikusa-ku, Nagoya, Aichi 464-8602, Japan"
+        }
+      ],
       "attrib": {
         "orcid": "0000-0003-3383-2279"
       }
@@ -50,37 +55,76 @@
       "name": {
         "surname": "Ohira",
         "given_name": "Yutaka"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Earth and Planetary Science, The University of Tokyo, 7-3-1 Hongo, Bunkyo-ku, Tokyo 113-0033, Japan"
+        }
+      ]
     },
     {
       "name": {
         "surname": "Bamba",
         "given_name": "Aya"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, Graduate School of Science, the University of Tokyo, 7-3-1 Hongo, Bunkyo-ku, Tokyo 113-0033, Japan"
+        },
+        {
+          "affPubRaw": "Research Center for the Early Universe, School of Science, The University of Tokyo, 7-3-1 Hongo, Bunkyo-ku, Tokyo 113-0033, Japan"
+        }
+      ]
     },
     {
       "name": {
         "surname": "Terada",
         "given_name": "Yukikatsu"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "Graduate School of Science and Engineering, Saitama University, 255 Shimo-Ohkubo, Saitama, Saitama 338-8570, Japan"
+        },
+        {
+          "affPubRaw": "Institute of Space and Astronautical Science, Japan Aerospace Exploration Agency, 3-1-1 Yoshinodai, Chuo, Sagamihara, Kanagawa 252-5210, Japan"
+        }
+      ]
     },
     {
       "name": {
         "surname": "Yamazaki",
         "given_name": "Ryo"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physical Sciences, Aoyama Gakuin University, 5-10-1 Fuchinobe, Chuo, Sagamihara, Kanagawa 252-5258, Japan"
+        },
+        {
+          "affPubRaw": "Institute of Laser Engineering, Osaka University, 2-6 Yamadaoka, Suita, Osaka 565-0871, Japan"
+        }
+      ]
     },
     {
       "name": {
         "surname": "Inoue",
         "given_name": "Tsuyoshi"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, Konan University, 8-9-1 Okamoto, Higashinada-ku, Kobe, Hyogo 658-8501, Japan"
+        }
+      ]
     },
     {
       "name": {
         "surname": "Tanaka",
         "given_name": "Shuta J"
-      }
+      },
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physical Sciences, Aoyama Gakuin University, 5-10-1 Fuchinobe, Chuo, Sagamihara, Kanagawa 252-5258, Japan"
+        }
+      ]
     }
   ],
   "title": {


### PR DESCRIPTION
This commit adds additional handling for crossref data for the case where records have affiliation data embedded in the `<affiliations>` tag, rather than `<affiliation>`