### PR TITLE
Improves affiliation capture from Crossref

### DIFF
--- a/adsingestp/parsers/crossref.py
+++ b/adsingestp/parsers/crossref.py
@@ -265,6 +265,30 @@ class CrossrefParser(BaseBeautifulSoupParser):
                 affil = [a.get_text() for a in c.find_all("affiliation")]
                 if affil:
                     contrib_tmp["aff"] = affil
+            elif c.find("affiliations"):
+                affil = []
+                institutions = c.find("affiliations").find_all("institution")
+                if institutions:
+                    for inst in institutions:
+                        name = inst.find("institution_name")
+                        dept = inst.find("institution_department")
+                        acro = inst.find("institution_acronym")
+                        place = inst.find("institution_place")
+                        taglist = []
+                        if dept:
+                            taglist.append(dept.get_text())
+                        if name:
+                            taglist.append(name.get_text())
+                        if acro:
+                            taglist.append(acro.get_text())
+                        if place:
+                            taglist.append(place.get_text())
+                        if taglist:
+                            affstring = ", ".join(taglist)
+                            affstring = re.sub(r"\s+,", ",", affstring)
+                            affil.append(affstring)
+                if affil:
+                    contrib_tmp["aff"] = affil
 
             role = c.get("contributor_role", "unknown")
 

--- a/tests/stubdata/output/crossref_cn_10.1093=mnras=stac2975.json
+++ b/tests/stubdata/output/crossref_cn_10.1093=mnras=stac2975.json
@@ -4,18 +4,36 @@
   },
   "authors": [
     {
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ],
       "name": {
         "given_name": "Haifeng",
         "surname": "Yang"
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ],
       "name": {
         "given_name": "Chenhui",
         "surname": "Shi"
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        },
+        {
+          "affPubRaw": "School of Computer Science and Technology, North University of China, Taiyuan 030051, China"
+        }
+      ],
       "attrib": {
         "orcid": "0000-0001-6945-8093"
       },
@@ -25,30 +43,55 @@
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ],
       "name": {
         "given_name": "Lichan",
         "surname": "Zhou"
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ],
       "name": {
         "given_name": "Yuqing",
         "surname": "Yang"
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ],
       "name": {
         "given_name": "Xujun",
         "surname": "Zhao"
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ],
       "name": {
         "given_name": "Yanting",
         "surname": "He"
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "School of Computer Science and Technology, Taiyuan University of Science and Technology, Taiyuan 030024, China"
+        }
+      ],
       "name": {
         "given_name": "Jing",
         "surname": "Hao"

--- a/tests/stubdata/output/crossref_cn_10.1093=pasj=psac053.json
+++ b/tests/stubdata/output/crossref_cn_10.1093=pasj=psac053.json
@@ -4,6 +4,11 @@
   },
   "authors": [
     {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, Graduate School of Science, Nagoya University, Furo-cho, Chikusa-ku, Nagoya, Aichi 464-8602, Japan"
+        }
+      ],
       "attrib": {
         "orcid": "0000-0003-3383-2279"
       },
@@ -13,36 +18,75 @@
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Earth and Planetary Science, The University of Tokyo, 7-3-1 Hongo, Bunkyo-ku, Tokyo 113-0033, Japan"
+        }
+      ],
       "name": {
         "given_name": "Yutaka",
         "surname": "Ohira"
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, Graduate School of Science, the University of Tokyo, 7-3-1 Hongo, Bunkyo-ku, Tokyo 113-0033, Japan"
+        },
+        {
+          "affPubRaw": "Research Center for the Early Universe, School of Science, The University of Tokyo, 7-3-1 Hongo, Bunkyo-ku, Tokyo 113-0033, Japan"
+        }
+      ],
       "name": {
         "given_name": "Aya",
         "surname": "Bamba"
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "Graduate School of Science and Engineering, Saitama University, 255 Shimo-Ohkubo, Saitama, Saitama 338-8570, Japan"
+        },
+        {
+          "affPubRaw": "Institute of Space and Astronautical Science, Japan Aerospace Exploration Agency, 3-1-1 Yoshinodai, Chuo, Sagamihara, Kanagawa 252-5210, Japan"
+        }
+      ],
       "name": {
         "given_name": "Yukikatsu",
         "surname": "Terada"
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physical Sciences, Aoyama Gakuin University, 5-10-1 Fuchinobe, Chuo, Sagamihara, Kanagawa 252-5258, Japan"
+        },
+        {
+          "affPubRaw": "Institute of Laser Engineering, Osaka University, 2-6 Yamadaoka, Suita, Osaka 565-0871, Japan"
+        }
+      ],
       "name": {
         "given_name": "Ryo",
         "surname": "Yamazaki"
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, Konan University, 8-9-1 Okamoto, Higashinada-ku, Kobe, Hyogo 658-8501, Japan"
+        }
+      ],
       "name": {
         "given_name": "Tsuyoshi",
         "surname": "Inoue"
       }
     },
     {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physical Sciences, Aoyama Gakuin University, 5-10-1 Fuchinobe, Chuo, Sagamihara, Kanagawa 252-5258, Japan"
+        }
+      ],
       "name": {
         "given_name": "Shuta J",
         "surname": "Tanaka"


### PR DESCRIPTION
 	modified:   adsingestp/parsers/crossref.py
 	modified:   tests/stubdata/output/crossref_cn_10.1093=mnras=stac2975.json
 	modified:   tests/stubdata/output/crossref_cn_10.1093=pasj=psac053.json

This PR addresses Issue #96 .  The broader issue of capturing ROR and other affiliation identifier data is raised in Issue #104 and will be the subject of a separate PR.