### PR TITLE
Fix aa collab.20241017

### DIFF
--- a/adsingestp/parsers/jats.py
+++ b/adsingestp/parsers/jats.py
@@ -335,9 +335,10 @@ class JATSAffils(object):
                         else:
                             # add new collab tag to each unnested author
                             collabtag = copy(contrib.find("collab").find("institution"))
-                            nested_contrib.append(collabtag)
-                            contribs_raw.insert(nested_idx, nested_contrib.extract())
-                            nested_idx += 1
+                            if collabtag:
+                                nested_contrib.append(collabtag)
+                                contribs_raw.insert(nested_idx, nested_contrib.extract())
+                                nested_idx += 1
 
                     continue
 

--- a/tests/stubdata/input/jats_edp_null_nested_collab_aa50368-24.xml
+++ b/tests/stubdata/input/jats_edp_null_nested_collab_aa50368-24.xml
@@ -1,0 +1,2378 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN" "JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" article-type="research-article" dtd-version="1.0" xml:lang="en">
+<front>
+<journal-meta>
+<journal-id journal-id-type="publisher-id">aa</journal-id><journal-id journal-id-type="url">https://www.aanda.org</journal-id>
+<journal-title-group>
+<journal-title>Astronomy &amp; Astrophysics</journal-title>
+<abbrev-journal-title abbrev-type="publisher">A&amp;A</abbrev-journal-title></journal-title-group>
+<issn pub-type="ppub">0004-6361</issn>
+<issn pub-type="epub">1432-0746</issn>
+<publisher><publisher-name>EDP Sciences</publisher-name></publisher></journal-meta>
+<article-meta>
+<article-id pub-id-type="doi">10.1051/0004-6361/202450368</article-id>
+<article-id pub-id-type="publisher-id">aa50368-24</article-id>
+<article-id pub-id-type="arxiv">2404.12157</article-id><article-id pub-id-type="other">2024A%26A...690A..30E</article-id><article-categories>
+<subj-group subj-group-type="section" xml:lang="en">
+<subject content-type="3">Cosmology (including clusters of galaxies)</subject>
+</subj-group></article-categories>
+<title-group>
+<article-title xml:lang="en"><italic>Euclid</italic> preparation</article-title>
+<subtitle xml:lang="en">XLVII. Improving cosmological constraints using a new multi-tracer method with the spectroscopic and photometric samples</subtitle>
+</title-group>
+<contrib-group content-type="authors">
+<contrib contrib-type="collab">
+<collab>Euclid Collaboration
+<contrib-group content-type="authors">
+<contrib contrib-type="author">
+<name><surname>Dournac</surname><given-names>F.</given-names></name>
+<xref rid="AFF1" ref-type="aff">1</xref>
+</contrib>
+<contrib contrib-type="author" corresp="yes">
+<contrib-id>http://orcid.org/0000-0001-8555-9003</contrib-id>
+<name><surname>Blanchard</surname><given-names>A.</given-names></name>
+<xref rid="AFF1" ref-type="aff">1</xref>
+<xref ref-type="corresp" rid="FN1">★</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-4285-9086</contrib-id>
+<name><surname>Ilić</surname><given-names>S.</given-names></name>
+<xref rid="AFF2" ref-type="aff">2</xref>
+<xref rid="AFF1" ref-type="aff">1</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-9416-2320</contrib-id>
+<name><surname>Lamine</surname><given-names>B.</given-names></name>
+<xref rid="AFF1" ref-type="aff">1</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3199-0399</contrib-id>
+<name><surname>Tutusaus</surname><given-names>I.</given-names></name>
+<xref rid="AFF1" ref-type="aff">1</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Amara</surname><given-names>A.</given-names></name>
+<xref rid="AFF3" ref-type="aff">3</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-2041-8784</contrib-id>
+<name><surname>Andreon</surname><given-names>S.</given-names></name>
+<xref rid="AFF4" ref-type="aff">4</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-4444-8651</contrib-id>
+<name><surname>Auricchio</surname><given-names>N.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-1371-5705</contrib-id>
+<name><surname>Aussel</surname><given-names>H.</given-names></name>
+<xref rid="AFF6" ref-type="aff">6</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-4145-1943</contrib-id>
+<name><surname>Baldi</surname><given-names>M.</given-names></name>
+<xref rid="AFF7" ref-type="aff">7</xref>
+<xref rid="AFF5" ref-type="aff">5</xref>
+<xref rid="AFF8" ref-type="aff">8</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-8900-0298</contrib-id>
+<name><surname>Bardelli</surname><given-names>S.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Bodendorf</surname><given-names>C.</given-names></name>
+<xref rid="AFF9" ref-type="aff">9</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3336-9977</contrib-id>
+<name><surname>Bonino</surname><given-names>D.</given-names></name>
+<xref rid="AFF10" ref-type="aff">10</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-0808-6908</contrib-id>
+<name><surname>Branchini</surname><given-names>E.</given-names></name>
+<xref rid="AFF11" ref-type="aff">11</xref>
+<xref rid="AFF12" ref-type="aff">12</xref>
+<xref rid="AFF4" ref-type="aff">4</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Brau-Nogue</surname><given-names>S.</given-names></name>
+<xref rid="AFF1" ref-type="aff">1</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-9506-5680</contrib-id>
+<name><surname>Brescia</surname><given-names>M.</given-names></name>
+<xref rid="AFF13" ref-type="aff">13</xref>
+<xref rid="AFF14" ref-type="aff">14</xref>
+<xref rid="AFF15" ref-type="aff">15</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-4359-8797</contrib-id>
+<name><surname>Brinchmann</surname><given-names>J.</given-names></name>
+<xref rid="AFF16" ref-type="aff">16</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-3399-3574</contrib-id>
+<name><surname>Camera</surname><given-names>S.</given-names></name>
+<xref rid="AFF17" ref-type="aff">17</xref>
+<xref rid="AFF18" ref-type="aff">18</xref>
+<xref rid="AFF10" ref-type="aff">10</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3309-7692</contrib-id>
+<name><surname>Capobianco</surname><given-names>V.</given-names></name>
+<xref rid="AFF10" ref-type="aff">10</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3130-0204</contrib-id>
+<name><surname>Carretero</surname><given-names>J.</given-names></name>
+<xref rid="AFF19" ref-type="aff">19</xref>
+<xref rid="AFF20" ref-type="aff">20</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4751-5138</contrib-id>
+<name><surname>Casas</surname><given-names>S.</given-names></name>
+<xref rid="AFF21" ref-type="aff">21</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-9875-8263</contrib-id>
+<name><surname>Castellano</surname><given-names>M.</given-names></name>
+<xref rid="AFF22" ref-type="aff">22</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3787-4196</contrib-id>
+<name><surname>Cavuoti</surname><given-names>S.</given-names></name>
+<xref rid="AFF14" ref-type="aff">14</xref>
+<xref rid="AFF15" ref-type="aff">15</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Cimatti</surname><given-names>A.</given-names></name>
+<xref rid="AFF23" ref-type="aff">23</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2508-0046</contrib-id>
+<name><surname>Congedo</surname><given-names>G.</given-names></name>
+<xref rid="AFF24" ref-type="aff">24</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Conselice</surname><given-names>C. J.</given-names></name>
+<xref rid="AFF25" ref-type="aff">25</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-6710-8476</contrib-id>
+<name><surname>Conversi</surname><given-names>L.</given-names></name>
+<xref rid="AFF26" ref-type="aff">26</xref>
+<xref rid="AFF27" ref-type="aff">27</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-5317-7518</contrib-id>
+<name><surname>Copin</surname><given-names>Y.</given-names></name>
+<xref rid="AFF28" ref-type="aff">28</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0758-6510</contrib-id>
+<name><surname>Courbin</surname><given-names>F.</given-names></name>
+<xref rid="AFF29" ref-type="aff">29</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0509-1776</contrib-id>
+<name><surname>Courtois</surname><given-names>H. M.</given-names></name>
+<xref rid="AFF30" ref-type="aff">30</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Da Silva</surname><given-names>A.</given-names></name>
+<xref rid="AFF31" ref-type="aff">31</xref>
+<xref rid="AFF32" ref-type="aff">32</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-5887-6799</contrib-id>
+<name><surname>Degaudenzi</surname><given-names>H.</given-names></name>
+<xref rid="AFF33" ref-type="aff">33</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4767-2360</contrib-id>
+<name><surname>Di Giorgio</surname><given-names>A. M.</given-names></name>
+<xref rid="AFF34" ref-type="aff">34</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-5075-1601</contrib-id>
+<name><surname>Dinis</surname><given-names>J.</given-names></name>
+<xref rid="AFF31" ref-type="aff">31</xref>
+<xref rid="AFF32" ref-type="aff">32</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-4203-3954</contrib-id>
+<name><surname>Douspis</surname><given-names>M.</given-names></name>
+<xref rid="AFF35" ref-type="aff">35</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-6533-2810</contrib-id>
+<name><surname>Dubath</surname><given-names>F.</given-names></name>
+<xref rid="AFF33" ref-type="aff">33</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Dupac</surname><given-names>X.</given-names></name>
+<xref rid="AFF27" ref-type="aff">27</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-1128-0664</contrib-id>
+<name><surname>Dusini</surname><given-names>S.</given-names></name>
+<xref rid="AFF36" ref-type="aff">36</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Ealet</surname><given-names>A.</given-names></name>
+<xref rid="AFF28" ref-type="aff">28</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3089-7846</contrib-id>
+<name><surname>Farina</surname><given-names>M.</given-names></name>
+<xref rid="AFF34" ref-type="aff">34</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-9594-9387</contrib-id>
+<name><surname>Farrens</surname><given-names>S.</given-names></name>
+<xref rid="AFF6" ref-type="aff">6</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Ferriol</surname><given-names>S.</given-names></name>
+<xref rid="AFF28" ref-type="aff">28</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-7400-2135</contrib-id>
+<name><surname>Frailis</surname><given-names>M.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-0585-6591</contrib-id>
+<name><surname>Franceschi</surname><given-names>E.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3748-5115</contrib-id>
+<name><surname>Galeotta</surname><given-names>S.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-4744-9748</contrib-id>
+<name><surname>Gillard</surname><given-names>W.</given-names></name>
+<xref rid="AFF38" ref-type="aff">38</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4478-1270</contrib-id>
+<name><surname>Gillis</surname><given-names>B.</given-names></name>
+<xref rid="AFF24" ref-type="aff">24</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-9590-7961</contrib-id>
+<name><surname>Giocoli</surname><given-names>C.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+<xref rid="AFF39" ref-type="aff">39</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2694-9284</contrib-id>
+<name><surname>Granett</surname><given-names>B. R.</given-names></name>
+<xref rid="AFF4" ref-type="aff">4</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-5688-0663</contrib-id>
+<name><surname>Grazian</surname><given-names>A.</given-names></name>
+<xref rid="AFF40" ref-type="aff">40</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Grupp</surname><given-names>F.</given-names></name>
+<xref rid="AFF9" ref-type="aff">9</xref>
+<xref rid="AFF41" ref-type="aff">41</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-9648-7260</contrib-id>
+<name><surname>Haugan</surname><given-names>S. V. H.</given-names></name>
+<xref rid="AFF42" ref-type="aff">42</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Holmes</surname><given-names>W.</given-names></name>
+<xref rid="AFF43" ref-type="aff">43</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-2960-978X</contrib-id>
+<name><surname>Hook</surname><given-names>I.</given-names></name>
+<xref rid="AFF44" ref-type="aff">44</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0009-0000-2474-3130</contrib-id>
+<name><surname>Hormuth</surname><given-names>F.</given-names></name>
+<xref rid="AFF45" ref-type="aff">45</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3363-0936</contrib-id>
+<name><surname>Hornstrup</surname><given-names>A.</given-names></name>
+<xref rid="AFF46" ref-type="aff">46</xref>
+<xref rid="AFF47" ref-type="aff">47</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Hudelot</surname><given-names>P.</given-names></name>
+<xref rid="AFF48" ref-type="aff">48</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-3804-2137</contrib-id>
+<name><surname>Jahnke</surname><given-names>K.</given-names></name>
+<xref rid="AFF49" ref-type="aff">49</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-1804-7715</contrib-id>
+<name><surname>Keihänen</surname><given-names>E.</given-names></name>
+<xref rid="AFF50" ref-type="aff">50</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-0302-5735</contrib-id>
+<name><surname>Kermiche</surname><given-names>S.</given-names></name>
+<xref rid="AFF38" ref-type="aff">38</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-2590-1273</contrib-id>
+<name><surname>Kiessling</surname><given-names>A.</given-names></name>
+<xref rid="AFF43" ref-type="aff">43</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-9513-7138</contrib-id>
+<name><surname>Kilbinger</surname><given-names>M.</given-names></name>
+<xref rid="AFF51" ref-type="aff">51</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0009-0006-5823-4880</contrib-id>
+<name><surname>Kubik</surname><given-names>B.</given-names></name>
+<xref rid="AFF28" ref-type="aff">28</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2791-2117</contrib-id>
+<name><surname>Kümmel</surname><given-names>M.</given-names></name>
+<xref rid="AFF41" ref-type="aff">41</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3052-7394</contrib-id>
+<name><surname>Kunz</surname><given-names>M.</given-names></name>
+<xref rid="AFF52" ref-type="aff">52</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4618-3063</contrib-id>
+<name><surname>Kurki-Suonio</surname><given-names>H.</given-names></name>
+<xref rid="AFF53" ref-type="aff">53</xref>
+<xref rid="AFF54" ref-type="aff">54</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-4172-4606</contrib-id>
+<name><surname>Ligori</surname><given-names>S.</given-names></name>
+<xref rid="AFF10" ref-type="aff">10</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-4324-7794</contrib-id>
+<name><surname>Lilje</surname><given-names>P. B.</given-names></name>
+<xref rid="AFF42" ref-type="aff">42</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2317-5471</contrib-id>
+<name><surname>Lindholm</surname><given-names>V.</given-names></name>
+<xref rid="AFF53" ref-type="aff">53</xref>
+<xref rid="AFF54" ref-type="aff">54</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-5966-1434</contrib-id>
+<name><surname>Lloro</surname><given-names>I.</given-names></name>
+<xref rid="AFF55" ref-type="aff">55</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4761-1242</contrib-id>
+<name><surname>Maino</surname><given-names>D.</given-names></name>
+<xref rid="AFF56" ref-type="aff">56</xref>
+<xref rid="AFF57" ref-type="aff">57</xref>
+<xref rid="AFF58" ref-type="aff">58</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2593-4355</contrib-id>
+<name><surname>Maiorano</surname><given-names>E.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-5758-4658</contrib-id>
+<name><surname>Mansutti</surname><given-names>O.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-7242-3852</contrib-id>
+<name><surname>Marggraf</surname><given-names>O.</given-names></name>
+<xref rid="AFF59" ref-type="aff">59</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-6764-073X</contrib-id>
+<name><surname>Markovic</surname><given-names>K.</given-names></name>
+<xref rid="AFF43" ref-type="aff">43</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2786-7790</contrib-id>
+<name><surname>Martinet</surname><given-names>N.</given-names></name>
+<xref rid="AFF60" ref-type="aff">60</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-8850-0303</contrib-id>
+<name><surname>Marulli</surname><given-names>F.</given-names></name>
+<xref rid="AFF61" ref-type="aff">61</xref>
+<xref rid="AFF5" ref-type="aff">5</xref>
+<xref rid="AFF8" ref-type="aff">8</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-6085-3780</contrib-id>
+<name><surname>Massey</surname><given-names>R.</given-names></name>
+<xref rid="AFF62" ref-type="aff">62</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Maurogordato</surname><given-names>S.</given-names></name>
+<xref rid="AFF63" ref-type="aff">63</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4040-7783</contrib-id>
+<name><surname>Medinaceli</surname><given-names>E.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-2849-559X</contrib-id>
+<name><surname>Mei</surname><given-names>S.</given-names></name>
+<xref rid="AFF64" ref-type="aff">64</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Mellier</surname><given-names>Y.</given-names></name>
+<xref rid="AFF65" ref-type="aff">65</xref>
+<xref rid="AFF48" ref-type="aff">48</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-1225-7084</contrib-id>
+<name><surname>Meneghetti</surname><given-names>M.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+<xref rid="AFF8" ref-type="aff">8</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-6870-8900</contrib-id>
+<name><surname>Merlin</surname><given-names>E.</given-names></name>
+<xref rid="AFF22" ref-type="aff">22</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Meylan</surname><given-names>G.</given-names></name>
+<xref rid="AFF29" ref-type="aff">29</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-7616-7136</contrib-id>
+<name><surname>Moresco</surname><given-names>M.</given-names></name>
+<xref rid="AFF61" ref-type="aff">61</xref>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3473-6716</contrib-id>
+<name><surname>Moscardini</surname><given-names>L.</given-names></name>
+<xref rid="AFF61" ref-type="aff">61</xref>
+<xref rid="AFF5" ref-type="aff">5</xref>
+<xref rid="AFF8" ref-type="aff">8</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-1751-5946</contrib-id>
+<name><surname>Munari</surname><given-names>E.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Niemi</surname><given-names>S.-M.</given-names></name>
+<xref rid="AFF66" ref-type="aff">66</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-8987-7401</contrib-id>
+<name><surname>Nightingale</surname><given-names>J. W.</given-names></name>
+<xref rid="AFF67" ref-type="aff">67</xref>
+<xref rid="AFF68" ref-type="aff">68</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-7951-0166</contrib-id>
+<name><surname>Padilla</surname><given-names>C.</given-names></name>
+<xref rid="AFF19" ref-type="aff">19</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-8108-9179</contrib-id>
+<name><surname>Paltani</surname><given-names>S.</given-names></name>
+<xref rid="AFF33" ref-type="aff">33</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4869-3227</contrib-id>
+<name><surname>Pasian</surname><given-names>F.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Pedersen</surname><given-names>K.</given-names></name>
+<xref rid="AFF69" ref-type="aff">69</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-0644-5727</contrib-id>
+<name><surname>Percival</surname><given-names>W. J.</given-names></name>
+<xref rid="AFF70" ref-type="aff">70</xref>
+<xref rid="AFF71" ref-type="aff">71</xref>
+<xref rid="AFF72" ref-type="aff">72</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4203-9320</contrib-id>
+<name><surname>Pettorino</surname><given-names>V.</given-names></name>
+<xref rid="AFF66" ref-type="aff">66</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-0249-2104</contrib-id>
+<name><surname>Pires</surname><given-names>S.</given-names></name>
+<xref rid="AFF6" ref-type="aff">6</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-4067-9196</contrib-id>
+<name><surname>Polenta</surname><given-names>G.</given-names></name>
+<xref rid="AFF73" ref-type="aff">73</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Poncet</surname><given-names>M.</given-names></name>
+<xref rid="AFF74" ref-type="aff">74</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-9045-9154</contrib-id>
+<name><surname>Popa</surname><given-names>L. A.</given-names></name>
+<xref rid="AFF75" ref-type="aff">75</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-7085-0412</contrib-id>
+<name><surname>Pozzetti</surname><given-names>L.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-7819-6918</contrib-id>
+<name><surname>Raison</surname><given-names>F.</given-names></name>
+<xref rid="AFF9" ref-type="aff">9</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Rebolo</surname><given-names>R.</given-names></name>
+<xref rid="AFF76" ref-type="aff">76</xref>
+<xref rid="AFF77" ref-type="aff">77</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-9856-1970</contrib-id>
+<name><surname>Renzi</surname><given-names>A.</given-names></name>
+<xref rid="AFF78" ref-type="aff">78</xref>
+<xref rid="AFF36" ref-type="aff">36</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4485-8549</contrib-id>
+<name><surname>Rhodes</surname><given-names>J.</given-names></name>
+<xref rid="AFF43" ref-type="aff">43</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-7020-1172</contrib-id>
+<name><surname>Riccio</surname><given-names>G.</given-names></name>
+<xref rid="AFF14" ref-type="aff">14</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-3069-9222</contrib-id>
+<name><surname>Romelli</surname><given-names>E.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-9587-7822</contrib-id>
+<name><surname>Roncarelli</surname><given-names>M.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Rossetti</surname><given-names>E.</given-names></name>
+<xref rid="AFF7" ref-type="aff">7</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0378-7032</contrib-id>
+<name><surname>Saglia</surname><given-names>R.</given-names></name>
+<xref rid="AFF41" ref-type="aff">41</xref>
+<xref rid="AFF9" ref-type="aff">9</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-7089-4503</contrib-id>
+<name><surname>Sapone</surname><given-names>D.</given-names></name>
+<xref rid="AFF79" ref-type="aff">79</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Schneider</surname><given-names>P.</given-names></name>
+<xref rid="AFF59" ref-type="aff">59</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0505-3710</contrib-id>
+<name><surname>Secroun</surname><given-names>A.</given-names></name>
+<xref rid="AFF38" ref-type="aff">38</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2907-353X</contrib-id>
+<name><surname>Seidel</surname><given-names>G.</given-names></name>
+<xref rid="AFF49" ref-type="aff">49</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-7536-9393</contrib-id>
+<name><surname>Seiffert</surname><given-names>M.</given-names></name>
+<xref rid="AFF43" ref-type="aff">43</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-0211-2861</contrib-id>
+<name><surname>Serrano</surname><given-names>S.</given-names></name>
+<xref rid="AFF80" ref-type="aff">80</xref>
+<xref rid="AFF81" ref-type="aff">81</xref>
+<xref rid="AFF82" ref-type="aff">82</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-0995-7146</contrib-id>
+<name><surname>Sirignano</surname><given-names>C.</given-names></name>
+<xref rid="AFF78" ref-type="aff">78</xref>
+<xref rid="AFF36" ref-type="aff">36</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2626-2853</contrib-id>
+<name><surname>Sirri</surname><given-names>G.</given-names></name>
+<xref rid="AFF8" ref-type="aff">8</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-9706-5104</contrib-id>
+<name><surname>Stanco</surname><given-names>L.</given-names></name>
+<xref rid="AFF36" ref-type="aff">36</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2592-0113</contrib-id>
+<name><surname>Surace</surname><given-names>C.</given-names></name>
+<xref rid="AFF60" ref-type="aff">60</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-1336-8328</contrib-id>
+<name><surname>Tallada-Crespí</surname><given-names>P.</given-names></name>
+<xref rid="AFF83" ref-type="aff">83</xref>
+<xref rid="AFF20" ref-type="aff">20</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-7475-9894</contrib-id>
+<name><surname>Tavagnacco</surname><given-names>D.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Taylor</surname><given-names>A. N.</given-names></name>
+<xref rid="AFF24" ref-type="aff">24</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Tereno</surname><given-names>I.</given-names></name>
+<xref rid="AFF31" ref-type="aff">31</xref>
+<xref rid="AFF84" ref-type="aff">84</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-2997-4859</contrib-id>
+<name><surname>Toledo-Moreo</surname><given-names>R.</given-names></name>
+<xref rid="AFF85" ref-type="aff">85</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-1160-1517</contrib-id>
+<name><surname>Torradeflot</surname><given-names>F.</given-names></name>
+<xref rid="AFF20" ref-type="aff">20</xref>
+<xref rid="AFF83" ref-type="aff">83</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Valentijn</surname><given-names>E. A.</given-names></name>
+<xref rid="AFF86" ref-type="aff">86</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-1170-0104</contrib-id>
+<name><surname>Valenziano</surname><given-names>L.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+<xref rid="AFF87" ref-type="aff">87</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-6512-6358</contrib-id>
+<name><surname>Vassallo</surname><given-names>T.</given-names></name>
+<xref rid="AFF41" ref-type="aff">41</xref>
+<xref rid="AFF37" ref-type="aff">37</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2387-1194</contrib-id>
+<name><surname>Veropalumbo</surname><given-names>A.</given-names></name>
+<xref rid="AFF4" ref-type="aff">4</xref>
+<xref rid="AFF12" ref-type="aff">12</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4749-2984</contrib-id>
+<name><surname>Wang</surname><given-names>Y.</given-names></name>
+<xref rid="AFF88" ref-type="aff">88</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0396-1192</contrib-id>
+<name><surname>Zacchei</surname><given-names>A.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+<xref rid="AFF89" ref-type="aff">89</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-2318-301X</contrib-id>
+<name><surname>Zamorani</surname><given-names>G.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-1962-9805</contrib-id>
+<name><surname>Zoubian</surname><given-names>J.</given-names></name>
+<xref rid="AFF38" ref-type="aff">38</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-5845-8132</contrib-id>
+<name><surname>Zucca</surname><given-names>E.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-0857-0732</contrib-id>
+<name><surname>Biviano</surname><given-names>A.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+<xref rid="AFF89" ref-type="aff">89</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-3278-4607</contrib-id>
+<name><surname>Bolzonella</surname><given-names>M.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-7387-2633</contrib-id>
+<name><surname>Boucaud</surname><given-names>A.</given-names></name>
+<xref rid="AFF64" ref-type="aff">64</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-8201-1525</contrib-id>
+<name><surname>Bozzo</surname><given-names>E.</given-names></name>
+<xref rid="AFF33" ref-type="aff">33</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3005-5796</contrib-id>
+<name><surname>Burigana</surname><given-names>C.</given-names></name>
+<xref rid="AFF90" ref-type="aff">90</xref>
+<xref rid="AFF87" ref-type="aff">87</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Colodro-Conde</surname><given-names>C.</given-names></name>
+<xref rid="AFF76" ref-type="aff">76</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-6220-9104</contrib-id>
+<name><surname>De Lucia</surname><given-names>G.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Di Ferdinando</surname><given-names>D.</given-names></name>
+<xref rid="AFF8" ref-type="aff">8</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Escartin Vigo</surname><given-names>J. A.</given-names></name>
+<xref rid="AFF9" ref-type="aff">9</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2212-367X</contrib-id>
+<name><surname>Farinelli</surname><given-names>R.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-4689-3134</contrib-id>
+<name><surname>Gracia-Carpio</surname><given-names>J.</given-names></name>
+<xref rid="AFF9" ref-type="aff">9</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2384-2377</contrib-id>
+<name><surname>Mainetti</surname><given-names>G.</given-names></name>
+<xref rid="AFF91" ref-type="aff">91</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-6943-7732</contrib-id>
+<name><surname>Martinelli</surname><given-names>M.</given-names></name>
+<xref rid="AFF22" ref-type="aff">22</xref>
+<xref rid="AFF92" ref-type="aff">92</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-8196-1548</contrib-id>
+<name><surname>Mauri</surname><given-names>N.</given-names></name>
+<xref rid="AFF23" ref-type="aff">23</xref>
+<xref rid="AFF8" ref-type="aff">8</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-8524-4968</contrib-id>
+<name><surname>Neissner</surname><given-names>C.</given-names></name>
+<xref rid="AFF19" ref-type="aff">19</xref>
+<xref rid="AFF20" ref-type="aff">20</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4823-3757</contrib-id>
+<name><surname>Sakr</surname><given-names>Z.</given-names></name>
+<xref rid="AFF93" ref-type="aff">93</xref>
+<xref rid="AFF1" ref-type="aff">1</xref>
+<xref rid="AFF94" ref-type="aff">94</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0009-0008-3864-940X</contrib-id>
+<name><surname>Scottez</surname><given-names>V.</given-names></name>
+<xref rid="AFF65" ref-type="aff">65</xref>
+<xref rid="AFF95" ref-type="aff">95</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4254-5901</contrib-id>
+<name><surname>Tenti</surname><given-names>M.</given-names></name>
+<xref rid="AFF8" ref-type="aff">8</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-2642-5707</contrib-id>
+<name><surname>Viel</surname><given-names>M.</given-names></name>
+<xref rid="AFF89" ref-type="aff">89</xref>
+<xref rid="AFF37" ref-type="aff">37</xref>
+<xref rid="AFF96" ref-type="aff">96</xref>
+<xref rid="AFF97" ref-type="aff">97</xref>
+<xref rid="AFF98" ref-type="aff">98</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0009-0000-8199-5860</contrib-id>
+<name><surname>Wiesmann</surname><given-names>M.</given-names></name>
+<xref rid="AFF42" ref-type="aff">42</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-2407-7956</contrib-id>
+<name><surname>Akrami</surname><given-names>Y.</given-names></name>
+<xref rid="AFF99" ref-type="aff">99</xref>
+<xref rid="AFF100" ref-type="aff">100</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-7232-5152</contrib-id>
+<name><surname>Allevato</surname><given-names>V.</given-names></name>
+<xref rid="AFF14" ref-type="aff">14</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3579-9583</contrib-id>
+<name><surname>Anselmi</surname><given-names>S.</given-names></name>
+<xref rid="AFF36" ref-type="aff">36</xref>
+<xref rid="AFF78" ref-type="aff">78</xref>
+<xref rid="AFF101" ref-type="aff">101</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-8211-1630</contrib-id>
+<name><surname>Baccigalupi</surname><given-names>C.</given-names></name>
+<xref rid="AFF96" ref-type="aff">96</xref>
+<xref rid="AFF37" ref-type="aff">37</xref>
+<xref rid="AFF97" ref-type="aff">97</xref>
+<xref rid="AFF89" ref-type="aff">89</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-5028-3035</contrib-id>
+<name><surname>Balaguera-Antolinez</surname><given-names>A.</given-names></name>
+<xref rid="AFF76" ref-type="aff">76</xref>
+<xref rid="AFF77" ref-type="aff">77</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-4481-3559</contrib-id>
+<name><surname>Ballardini</surname><given-names>M.</given-names></name>
+<xref rid="AFF102" ref-type="aff">102</xref>
+<xref rid="AFF5" ref-type="aff">5</xref>
+<xref rid="AFF103" ref-type="aff">103</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-9622-7167</contrib-id>
+<name><surname>Blot</surname><given-names>L.</given-names></name>
+<xref rid="AFF104" ref-type="aff">104</xref>
+<xref rid="AFF101" ref-type="aff">101</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-6151-6439</contrib-id>
+<name><surname>Borgani</surname><given-names>S.</given-names></name>
+<xref rid="AFF105" ref-type="aff">105</xref>
+<xref rid="AFF89" ref-type="aff">89</xref>
+<xref rid="AFF37" ref-type="aff">37</xref>
+<xref rid="AFF97" ref-type="aff">97</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-6503-5218</contrib-id>
+<name><surname>Bruton</surname><given-names>S.</given-names></name>
+<xref rid="AFF106" ref-type="aff">106</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-6679-2600</contrib-id>
+<name><surname>Cabanac</surname><given-names>R.</given-names></name>
+<xref rid="AFF1" ref-type="aff">1</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Calabro</surname><given-names>A.</given-names></name>
+<xref rid="AFF22" ref-type="aff">22</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2796-2149</contrib-id>
+<name><surname>Canas-Herrera</surname><given-names>G.</given-names></name>
+<xref rid="AFF66" ref-type="aff">66</xref>
+<xref rid="AFF107" ref-type="aff">107</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-9200-7167</contrib-id>
+<name><surname>Cappi</surname><given-names>A.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+<xref rid="AFF63" ref-type="aff">63</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Carvalho</surname><given-names>C. S.</given-names></name>
+<xref rid="AFF84" ref-type="aff">84</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-6831-0687</contrib-id>
+<name><surname>Castignani</surname><given-names>G.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-6292-3228</contrib-id>
+<name><surname>Castro</surname><given-names>T.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+<xref rid="AFF97" ref-type="aff">97</xref>
+<xref rid="AFF89" ref-type="aff">89</xref>
+<xref rid="AFF98" ref-type="aff">98</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-6965-7789</contrib-id>
+<name><surname>Chambers</surname><given-names>K. C.</given-names></name>
+<xref rid="AFF108" ref-type="aff">108</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-9843-723X</contrib-id>
+<name><surname>Contarini</surname><given-names>S.</given-names></name>
+<xref rid="AFF9" ref-type="aff">9</xref>
+<xref rid="AFF61" ref-type="aff">61</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3892-0190</contrib-id>
+<name><surname>Cooray</surname><given-names>A. R.</given-names></name>
+<xref rid="AFF109" ref-type="aff">109</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Coupon</surname><given-names>J.</given-names></name>
+<xref rid="AFF33" ref-type="aff">33</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-3269-1718</contrib-id>
+<name><surname>Davini</surname><given-names>S.</given-names></name>
+<xref rid="AFF12" ref-type="aff">12</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>De Caro</surname><given-names>B.</given-names></name>
+<xref rid="AFF36" ref-type="aff">36</xref>
+<xref rid="AFF78" ref-type="aff">78</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>de la Torre</surname><given-names>S.</given-names></name>
+<xref rid="AFF60" ref-type="aff">60</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Desprez</surname><given-names>G.</given-names></name>
+<xref rid="AFF110" ref-type="aff">110</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0748-4768</contrib-id>
+<name><surname>Díaz-Sánchez</surname><given-names>A.</given-names></name>
+<xref rid="AFF111" ref-type="aff">111</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2863-5895</contrib-id>
+<name><surname>Di Domizio</surname><given-names>S.</given-names></name>
+<xref rid="AFF11" ref-type="aff">11</xref>
+<xref rid="AFF12" ref-type="aff">12</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-9767-3839</contrib-id>
+<name><surname>Dole</surname><given-names>H.</given-names></name>
+<xref rid="AFF35" ref-type="aff">35</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-2847-7498</contrib-id>
+<name><surname>Escoffier</surname><given-names>S.</given-names></name>
+<xref rid="AFF38" ref-type="aff">38</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0009-0005-5266-4110</contrib-id>
+<name><surname>Ferrari</surname><given-names>A. G.</given-names></name>
+<xref rid="AFF23" ref-type="aff">23</xref>
+<xref rid="AFF8" ref-type="aff">8</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3021-2851</contrib-id>
+<name><surname>Ferreira</surname><given-names>P. G.</given-names></name>
+<xref rid="AFF112" ref-type="aff">112</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-1295-1132</contrib-id>
+<name><surname>Ferrero</surname><given-names>I.</given-names></name>
+<xref rid="AFF42" ref-type="aff">42</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-6694-3269</contrib-id>
+<name><surname>Finelli</surname><given-names>F.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+<xref rid="AFF87" ref-type="aff">87</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-8486-8856</contrib-id>
+<name><surname>Gabarra</surname><given-names>L.</given-names></name>
+<xref rid="AFF112" ref-type="aff">112</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-8159-8208</contrib-id>
+<name><surname>Ganga</surname><given-names>K.</given-names></name>
+<xref rid="AFF64" ref-type="aff">64</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-9370-8360</contrib-id>
+<name><surname>García-Bellido</surname><given-names>J.</given-names></name>
+<xref rid="AFF99" ref-type="aff">99</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-9632-0815</contrib-id>
+<name><surname>Gaztanaga</surname><given-names>E.</given-names></name>
+<xref rid="AFF81" ref-type="aff">81</xref>
+<xref rid="AFF80" ref-type="aff">80</xref>
+<xref rid="AFF113" ref-type="aff">113</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3129-2814</contrib-id>
+<name><surname>Giacomini</surname><given-names>F.</given-names></name>
+<xref rid="AFF8" ref-type="aff">8</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-0236-919X</contrib-id>
+<name><surname>Gozaliasl</surname><given-names>G.</given-names></name>
+<xref rid="AFF114" ref-type="aff">114</xref>
+<xref rid="AFF53" ref-type="aff">53</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-9814-3338</contrib-id>
+<name><surname>Hildebrandt</surname><given-names>H.</given-names></name>
+<xref rid="AFF115" ref-type="aff">115</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0009-0004-5252-185X</contrib-id>
+<name><surname>Jimenez Munoz</surname><given-names>A.</given-names></name>
+<xref rid="AFF116" ref-type="aff">116</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-3010-8333</contrib-id>
+<name><surname>Kajava</surname><given-names>J. J. E.</given-names></name>
+<xref rid="AFF117" ref-type="aff">117</xref>
+<xref rid="AFF118" ref-type="aff">118</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4008-6078</contrib-id>
+<name><surname>Kansal</surname><given-names>V.</given-names></name>
+<xref rid="AFF119" ref-type="aff">119</xref>
+<xref rid="AFF120" ref-type="aff">120</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4927-0816</contrib-id>
+<name><surname>Karagiannis</surname><given-names>D.</given-names></name>
+<xref rid="AFF121" ref-type="aff">121</xref>
+<xref rid="AFF122" ref-type="aff">122</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Kirkpatrick</surname><given-names>C. C.</given-names></name>
+<xref rid="AFF50" ref-type="aff">50</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0610-5252</contrib-id>
+<name><surname>Legrand</surname><given-names>L.</given-names></name>
+<xref rid="AFF123" ref-type="aff">123</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Libet</surname><given-names>G.</given-names></name>
+<xref rid="AFF74" ref-type="aff">74</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4371-0876</contrib-id>
+<name><surname>Loureiro</surname><given-names>A.</given-names></name>
+<xref rid="AFF124" ref-type="aff">124</xref>
+<xref rid="AFF125" ref-type="aff">125</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-5385-2763</contrib-id>
+<name><surname>Macias-Perez</surname><given-names>J.</given-names></name>
+<xref rid="AFF116" ref-type="aff">116</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-4020-4836</contrib-id>
+<name><surname>Maggio</surname><given-names>G.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-9158-4838</contrib-id>
+<name><surname>Magliocchetti</surname><given-names>M.</given-names></name>
+<xref rid="AFF34" ref-type="aff">34</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4803-2381</contrib-id>
+<name><surname>Mannucci</surname><given-names>F.</given-names></name>
+<xref rid="AFF126" ref-type="aff">126</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-6065-3025</contrib-id>
+<name><surname>Maoli</surname><given-names>R.</given-names></name>
+<xref rid="AFF127" ref-type="aff">127</xref>
+<xref rid="AFF22" ref-type="aff">22</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-4886-9261</contrib-id>
+<name><surname>Martins</surname><given-names>C. J. A. P.</given-names></name>
+<xref rid="AFF128" ref-type="aff">128</xref>
+<xref rid="AFF16" ref-type="aff">16</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Matthew</surname><given-names>S.</given-names></name>
+<xref rid="AFF24" ref-type="aff">24</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-8406-0857</contrib-id>
+<name><surname>Maurin</surname><given-names>L.</given-names></name>
+<xref rid="AFF35" ref-type="aff">35</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-3167-2574</contrib-id>
+<name><surname>Metcalf</surname><given-names>R. B.</given-names></name>
+<xref rid="AFF61" ref-type="aff">61</xref>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Migliaccio</surname><given-names>M.</given-names></name>
+<xref rid="AFF129" ref-type="aff">129</xref>
+<xref rid="AFF130" ref-type="aff">130</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2083-7564</contrib-id>
+<name><surname>Monaco</surname><given-names>P.</given-names></name>
+<xref rid="AFF105" ref-type="aff">105</xref>
+<xref rid="AFF37" ref-type="aff">37</xref>
+<xref rid="AFF97" ref-type="aff">97</xref>
+<xref rid="AFF89" ref-type="aff">89</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-3314-8936</contrib-id>
+<name><surname>Moretti</surname><given-names>C.</given-names></name>
+<xref rid="AFF96" ref-type="aff">96</xref>
+<xref rid="AFF98" ref-type="aff">98</xref>
+<xref rid="AFF37" ref-type="aff">37</xref>
+<xref rid="AFF89" ref-type="aff">89</xref>
+<xref rid="AFF97" ref-type="aff">97</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Morgante</surname><given-names>G.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-9070-3102</contrib-id>
+<name><surname>Nadathur</surname><given-names>S.</given-names></name>
+<xref rid="AFF113" ref-type="aff">113</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-3983-8778</contrib-id>
+<name><surname>Walton</surname><given-names>N. A.</given-names></name>
+<xref rid="AFF131" ref-type="aff">131</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-9712-977X</contrib-id>
+<name><surname>Patrizii</surname><given-names>L.</given-names></name>
+<xref rid="AFF8" ref-type="aff">8</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0726-2268</contrib-id>
+<name><surname>Pezzotta</surname><given-names>A.</given-names></name>
+<xref rid="AFF9" ref-type="aff">9</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-5442-2530</contrib-id>
+<name><surname>Pöntinen</surname><given-names>M.</given-names></name>
+<xref rid="AFF53" ref-type="aff">53</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Popa</surname><given-names>V.</given-names></name>
+<xref rid="AFF75" ref-type="aff">75</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-7797-2508</contrib-id>
+<name><surname>Porciani</surname><given-names>C.</given-names></name>
+<xref rid="AFF59" ref-type="aff">59</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-0757-5195</contrib-id>
+<name><surname>Potter</surname><given-names>D.</given-names></name>
+<xref rid="AFF132" ref-type="aff">132</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-2525-7761</contrib-id>
+<name><surname>Risso</surname><given-names>I.</given-names></name>
+<xref rid="AFF133" ref-type="aff">133</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-8106-2702</contrib-id>
+<name><surname>Rocci</surname><given-names>P.-F.</given-names></name>
+<xref rid="AFF35" ref-type="aff">35</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0973-4804</contrib-id>
+<name><surname>Sahlén</surname><given-names>M.</given-names></name>
+<xref rid="AFF134" ref-type="aff">134</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-1198-831X</contrib-id>
+<name><surname>Sánchez</surname><given-names>A. G.</given-names></name>
+<xref rid="AFF9" ref-type="aff">9</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Schewtschenko</surname><given-names>J. A.</given-names></name>
+<xref rid="AFF24" ref-type="aff">24</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-7055-8104</contrib-id>
+<name><surname>Schneider</surname><given-names>A.</given-names></name>
+<xref rid="AFF132" ref-type="aff">132</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0473-1567</contrib-id>
+<name><surname>Sefusatti</surname><given-names>E.</given-names></name>
+<xref rid="AFF37" ref-type="aff">37</xref>
+<xref rid="AFF89" ref-type="aff">89</xref>
+<xref rid="AFF97" ref-type="aff">97</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0302-0325</contrib-id>
+<name><surname>Sereno</surname><given-names>M.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+<xref rid="AFF8" ref-type="aff">8</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-7443-1047</contrib-id>
+<name><surname>Steinwagner</surname><given-names>J.</given-names></name>
+<xref rid="AFF9" ref-type="aff">9</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-9696-7931</contrib-id>
+<name><surname>Tessore</surname><given-names>N.</given-names></name>
+<xref rid="AFF135" ref-type="aff">135</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Testera</surname><given-names>G.</given-names></name>
+<xref rid="AFF12" ref-type="aff">12</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-7689-0933</contrib-id>
+<name><surname>Teyssier</surname><given-names>R.</given-names></name>
+<xref rid="AFF136" ref-type="aff">136</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-3631-7176</contrib-id>
+<name><surname>Toft</surname><given-names>S.</given-names></name>
+<xref rid="AFF47" ref-type="aff">47</xref>
+<xref rid="AFF137" ref-type="aff">137</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-7275-9193</contrib-id>
+<name><surname>Tosi</surname><given-names>S.</given-names></name>
+<xref rid="AFF11" ref-type="aff">11</xref>
+<xref rid="AFF4" ref-type="aff">4</xref>
+<xref rid="AFF12" ref-type="aff">12</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0239-4595</contrib-id>
+<name><surname>Troja</surname><given-names>A.</given-names></name>
+<xref rid="AFF78" ref-type="aff">78</xref>
+<xref rid="AFF36" ref-type="aff">36</xref>
+</contrib>
+<contrib contrib-type="author">
+<name><surname>Tucci</surname><given-names>M.</given-names></name>
+<xref rid="AFF33" ref-type="aff">33</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0001-6225-3693</contrib-id>
+<name><surname>Valiviita</surname><given-names>J.</given-names></name>
+<xref rid="AFF53" ref-type="aff">53</xref>
+<xref rid="AFF54" ref-type="aff">54</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0003-0898-2216</contrib-id>
+<name><surname>Vergani</surname><given-names>D.</given-names></name>
+<xref rid="AFF5" ref-type="aff">5</xref>
+</contrib>
+<contrib contrib-type="author">
+<contrib-id>http://orcid.org/0000-0002-1886-8348</contrib-id>
+<name><surname>Verza</surname><given-names>G.</given-names></name>
+<xref rid="AFF138" ref-type="aff">138</xref>
+<xref rid="AFF139" ref-type="aff">139</xref>
+</contrib>
+</contrib-group>
+</collab>
+</contrib>
+</contrib-group>
+<aff id="AFF1"><label>1</label>
+<addr-line>
+<institution>Institut de Recherche en Astrophysique et Planétologie (IRAP), Université de Toulouse, CNRS, UPS, CNES</institution>, 
+<named-content content-type="street">14 Av. Edouard Belin</named-content>, 
+<named-content content-type="postcode">31400</named-content> 
+<named-content content-type="city">Toulouse</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF2"><label>2</label>
+<addr-line>
+<institution>Université Paris-Saclay, CNRS/IN2P3, IJCLab</institution>, 
+<named-content content-type="postcode">91405</named-content> 
+<named-content content-type="city">Orsay</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF3"><label>3</label>
+<addr-line>
+<institution>School of Mathematics and Physics, University of Surrey</institution>, 
+<named-content content-type="city">Guildford</named-content>, 
+<named-content content-type="state">Surrey</named-content>, 
+<named-content content-type="postcode">GU2 7XH</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF4"><label>4</label>
+<addr-line>
+<institution>INAF-Osservatorio Astronomico di Brera</institution>, 
+<named-content content-type="street">Via Brera 28</named-content>, 
+<named-content content-type="postcode">20122</named-content> 
+<named-content content-type="city">Milano</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF5"><label>5</label>
+<addr-line>
+<institution>INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna</institution>, 
+<named-content content-type="street">Via Piero Gobetti 93/3</named-content>, 
+<named-content content-type="postcode">40129</named-content> 
+<named-content content-type="city">Bologna</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF6"><label>6</label>
+<addr-line>
+<institution>Université Paris-Saclay, Université Paris Cité, CEA, CNRS, AIM</institution>, 
+<named-content content-type="postcode">91191</named-content> 
+<named-content content-type="city">Gif-sur-Yvette</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF7"><label>7</label>
+<addr-line>
+<institution>Dipartimento di Fisica e Astronomia, Università di Bologna</institution>, 
+<named-content content-type="street">Via Gobetti 93/2</named-content>, 
+<named-content content-type="postcode">40129</named-content> 
+<named-content content-type="city">Bologna</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF8"><label>8</label>
+<addr-line>
+<institution>INFN-Sezione di Bologna</institution>, 
+<named-content content-type="street">Viale Berti Pichat 6/2</named-content>, 
+<named-content content-type="postcode">40127</named-content> 
+<named-content content-type="city">Bologna</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF9"><label>9</label>
+<addr-line>
+<institution>Max Planck Institute for Extraterrestrial Physics</institution>, 
+<named-content content-type="street">Giessenbachstr. 1</named-content>, 
+<named-content content-type="postcode">85748</named-content> 
+<named-content content-type="city">Garching</named-content>, 
+<country>Germany</country></addr-line></aff>
+<aff id="AFF10"><label>10</label>
+<addr-line>
+<institution>INAF-Osservatorio Astrofisico di Torino</institution>, 
+<named-content content-type="street">Via Osservatorio 20</named-content>, 
+<named-content content-type="postcode">10025</named-content> 
+<named-content content-type="city">Pino Torinese (TO)</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF11"><label>11</label>
+<addr-line>
+<institution>Dipartimento di Fisica, Università di Genova</institution>, 
+<named-content content-type="street">Via Dodecaneso 33</named-content>, 
+<named-content content-type="postcode">16146</named-content>, 
+<named-content content-type="city">Genova</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF12"><label>12</label>
+<addr-line>
+<institution>INFN-Sezione di Genova</institution>, 
+<named-content content-type="street">Via Dodecaneso 33</named-content>, 
+<named-content content-type="postcode">16146</named-content> 
+<named-content content-type="city">Genova</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF13"><label>13</label>
+<addr-line>
+<institution>Department of Physics “E. Pancini”, University Federico II</institution>, 
+<named-content content-type="street">Via Cinthia 6</named-content>, 
+<named-content content-type="postcode">80126</named-content> 
+<named-content content-type="city">Napoli</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF14"><label>14</label>
+<addr-line>
+<institution>INAF-Osservatorio Astronomico di Capodimonte</institution>, 
+<named-content content-type="street">Via Moiariello 16</named-content>, 
+<named-content content-type="postcode">80131</named-content> 
+<named-content content-type="city">Napoli</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF15"><label>15</label>
+<addr-line>
+<institution>INFN section of Naples</institution>, 
+<named-content content-type="street">Via Cinthia 6</named-content>, 
+<named-content content-type="postcode">80126</named-content> 
+<named-content content-type="city">Napoli</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF16"><label>16</label>
+<addr-line>
+<institution>Instituto de Astrofísica e Ciências do Espaço, Universidade do Porto, CAUP</institution>, 
+<named-content content-type="street">Rua das Estrelas</named-content>, 
+<named-content content-type="postcode">PT4150-762</named-content> 
+<named-content content-type="city">Porto</named-content>, 
+<country>Portugal</country></addr-line></aff>
+<aff id="AFF17"><label>17</label>
+<addr-line>
+<institution>Dipartimento di Fisica, Università degli Studi di Torino</institution>, 
+<named-content content-type="street">Via P. Giuria 1</named-content>, 
+<named-content content-type="postcode">10125</named-content> 
+<named-content content-type="city">Torino</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF18"><label>18</label>
+<addr-line>
+<institution>INFN-Sezione di Torino</institution>, 
+<named-content content-type="street">Via P. Giuria 1</named-content>, 
+<named-content content-type="postcode">10125</named-content> 
+<named-content content-type="city">Torino</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF19"><label>19</label>
+<addr-line>
+<institution>Institut de Física d’Altes Energies (IFAE), The Barcelona Institute of Science and Technology</institution>, 
+<named-content content-type="street">Campus UAB</named-content>, 
+<named-content content-type="postcode">08193</named-content> 
+<named-content content-type="city">Bellaterra (Barcelona)</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF20"><label>20</label>
+<addr-line>
+<institution>Port d’Informació Científica</institution>, 
+<named-content content-type="street">Campus UAB, C. Albareda s/n</named-content>, 
+<named-content content-type="postcode">08193</named-content> 
+<named-content content-type="city">Bellaterra (Barcelona)</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF21"><label>21</label>
+<addr-line>
+<institution>Institute for Theoretical Particle Physics and Cosmology (TTK), RWTH Aachen University</institution>, 
+<named-content content-type="postcode">52056</named-content> 
+<named-content content-type="city">Aachen</named-content>, 
+<country>Germany</country></addr-line></aff>
+<aff id="AFF22"><label>22</label>
+<addr-line>
+<institution>INAF-Osservatorio Astronomico di Roma</institution>, 
+<named-content content-type="street">Via Frascati 33</named-content>, 
+<named-content content-type="postcode">00078</named-content> 
+<named-content content-type="city">Monteporzio Catone</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF23"><label>23</label>
+<addr-line>
+<institution>Dipartimento di Fisica e Astronomia “Augusto Righi” - Alma Mater Studiorum Università di Bologna</institution>, 
+<named-content content-type="street">Viale Berti Pichat 6/2</named-content>, 
+<named-content content-type="postcode">40127</named-content> 
+<named-content content-type="city">Bologna</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF24"><label>24</label>
+<addr-line>
+<institution>Institute for Astronomy, University of Edinburgh</institution>, 
+<named-content content-type="street">Royal Observatory, Blackford Hill</named-content>, 
+<named-content content-type="city">Edinburgh</named-content> 
+<named-content content-type="postcode">EH9 3HJ</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF25"><label>25</label>
+<addr-line>
+<institution>Jodrell Bank Centre for Astrophysics, Department of Physics and Astronomy, University of Manchester</institution>, 
+<named-content content-type="street">Oxford Road</named-content>, 
+<named-content content-type="city">Manchester</named-content> 
+<named-content content-type="postcode">M13 9PL</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF26"><label>26</label>
+<addr-line>
+<institution>European Space Agency/ESRIN</institution>, 
+<named-content content-type="street">Largo Galileo Galilei 1</named-content>, 
+<named-content content-type="postcode">00044</named-content> 
+<named-content content-type="city">Frascati, Roma</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF27"><label>27</label>
+<addr-line>
+<institution>ESAC/ESA, Camino Bajo del Castillo</institution>, 
+<named-content content-type="street">s/n., Urb. Villafranca del Castillo</named-content>, 
+<named-content content-type="postcode">28692</named-content> 
+<named-content content-type="street">Villanueva de la Cañada</named-content>, 
+<named-content content-type="city">Madrid</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF28"><label>28</label>
+<addr-line>
+<institution>Université Claude Bernard Lyon 1</institution>, 
+<named-content content-type="street">CNRS/IN2P3, IP2I Lyon, UMR 5822</named-content>, 
+<named-content content-type="postcode">69100</named-content> 
+<named-content content-type="city">Villeurbanne</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF29"><label>29</label>
+<addr-line>
+<institution>Institute of Physics, Laboratory of Astrophysics, Ecole Polytechnique Fédérale de Lausanne (EPFL)</institution>, 
+<named-content content-type="street">Observatoire de Sauverny</named-content>, 
+<named-content content-type="postcode">1290</named-content> 
+<named-content content-type="city">Versoix</named-content>, 
+<country>Switzerland</country></addr-line></aff>
+<aff id="AFF30"><label>30</label>
+<addr-line>
+<institution>UCB Lyon 1</institution>, 
+<named-content content-type="street">CNRS/IN2P3, IUF, IP2I Lyon, 4 rue Enrico Fermi</named-content>, 
+<named-content content-type="postcode">69622</named-content> 
+<named-content content-type="city">Villeurbanne</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF31"><label>31</label>
+<addr-line>
+<institution>Departamento de Física, Faculdade de Ciências, Universidade de Lisboa</institution>, 
+<named-content content-type="street">Edifício C8, Campo Grande</named-content>, 
+<named-content content-type="postcode">PT1749-016</named-content> 
+<named-content content-type="city">Lisboa</named-content>, 
+<country>Portugal</country></addr-line></aff>
+<aff id="AFF32"><label>32</label>
+<addr-line>
+<institution>Instituto de Astrofísica e Ciências do Espaço, Faculdade de Ciên- cias, Universidade de Lisboa</institution>, 
+<named-content content-type="street">Campo Grande</named-content>, 
+<named-content content-type="postcode">1749-016</named-content> 
+<named-content content-type="city">Lisboa</named-content>, 
+<country>Portugal</country></addr-line></aff>
+<aff id="AFF33"><label>33</label>
+<addr-line>
+<institution>Department of Astronomy, University of Geneva</institution>, 
+<named-content content-type="street">ch. d’Ecogia 16</named-content>, 
+<named-content content-type="postcode">1290</named-content> 
+<named-content content-type="city">Versoix</named-content>, 
+<country>Switzerland</country></addr-line></aff>
+<aff id="AFF34"><label>34</label>
+<addr-line>
+<institution>INAF-Istituto di Astrofisica e Planetologia Spaziali</institution>, 
+<named-content content-type="street">via del Fosso del Cavaliere, 100</named-content>, 
+<named-content content-type="postcode">00100</named-content> 
+<named-content content-type="city">Roma</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF35"><label>35</label>
+<addr-line>
+<institution>Université Paris-Saclay, CNRS, Institut d’astrophysique spatiale</institution>, 
+<named-content content-type="postcode">91405</named-content> 
+<named-content content-type="city">Orsay</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF36"><label>36</label>
+<addr-line>
+<institution>INFN-Padova</institution>, 
+<named-content content-type="street">Via Marzolo 8</named-content>, 
+<named-content content-type="postcode">35131</named-content> 
+<named-content content-type="city">Padova</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF37"><label>37</label>
+<addr-line>
+<institution>INAF-Osservatorio Astronomico di Trieste</institution>, 
+<named-content content-type="street">Via G. B. Tiepolo 11</named-content>, 
+<named-content content-type="postcode">34143</named-content> 
+<named-content content-type="city">Trieste</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF38"><label>38</label>
+<addr-line>
+<institution>Aix-Marseille Université, CNRS/IN2P3, CPPM</institution>, 
+<named-content content-type="city">Marseille</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF39"><label>39</label>
+<addr-line>
+<institution>Istituto Nazionale di Fisica Nucleare</institution>, 
+<named-content content-type="street">Sezione di Bologna, Via Irnerio 46</named-content>, 
+<named-content content-type="postcode">40126</named-content> 
+<named-content content-type="city">Bologna</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF40"><label>40</label>
+<addr-line>
+<institution>INAF-Osservatorio Astronomico di Padova</institution>, 
+<named-content content-type="street">Via dell’Osservatorio 5</named-content>, 
+<named-content content-type="postcode">35122</named-content> 
+<named-content content-type="city">Padova</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF41"><label>41</label>
+<addr-line>
+<institution>Universitäts-Sternwarte München, Fakultät für Physik, Ludwig-Maximilians-Universität München</institution>, 
+<named-content content-type="street">Scheinerstrasse 1</named-content>, 
+<named-content content-type="postcode">81679</named-content> 
+<named-content content-type="city">München</named-content>, 
+<country>Germany</country></addr-line></aff>
+<aff id="AFF42"><label>42</label>
+<addr-line>
+<institution>Institute of Theoretical Astrophysics, University of Oslo</institution>, 
+<named-content content-type="postbox">PO Box 1029</named-content> 
+<named-content content-type="street">Blindern</named-content>, 
+<named-content content-type="postcode">0315</named-content> 
+<named-content content-type="city">Oslo</named-content>, 
+<country>Norway</country></addr-line></aff>
+<aff id="AFF43"><label>43</label>
+<addr-line>
+<institution>Jet Propulsion Laboratory, California Institute of Technology</institution>, 
+<named-content content-type="street">4800 Oak Grove Drive</named-content>, 
+<named-content content-type="city">Pasadena</named-content>, 
+<named-content content-type="state">CA</named-content>, 
+<named-content content-type="postcode">91109</named-content>, 
+<country>USA</country></addr-line></aff>
+<aff id="AFF44"><label>44</label>
+<addr-line>
+<institution>Department of Physics, Lancaster University</institution>, 
+<named-content content-type="city">Lancaster</named-content>, 
+<named-content content-type="postcode">LA1 4YB</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF45"><label>45</label>
+<addr-line>
+<institution>Felix Hormuth Engineering</institution>, 
+<named-content content-type="street">Goethestr. 17</named-content>, 
+<named-content content-type="postcode">69181</named-content> 
+<named-content content-type="city">Leimen</named-content>, 
+<country>Germany</country></addr-line></aff>
+<aff id="AFF46"><label>46</label>
+<addr-line>
+<institution>Technical University of Denmark</institution>, 
+<named-content content-type="street">Elektrovej 327, 2800 Kgs.</named-content> 
+<named-content content-type="city">Lyngby</named-content>, 
+<country>Denmark</country></addr-line></aff>
+<aff id="AFF47"><label>47</label>
+<addr-line>
+<institution>Cosmic Dawn Center (DAWN)</institution>, 
+<country>Denmark</country></addr-line></aff>
+<aff id="AFF48"><label>48</label>
+<addr-line>
+<institution>Institut d’Astrophysique de Paris</institution>, 
+<named-content content-type="street">UMR 7095, CNRS, and Sorbonne Université, 98 bis boulevard Arago</named-content>, 
+<named-content content-type="postcode">75014</named-content> 
+<named-content content-type="city">Paris</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF49"><label>49</label>
+<addr-line>
+<institution>Max-Planck-Institut für Astronomie</institution>, 
+<named-content content-type="street">Königstuhl 17</named-content>, 
+<named-content content-type="postcode">69117</named-content> 
+<named-content content-type="city">Heidelberg</named-content>, 
+<country>Germany</country></addr-line></aff>
+<aff id="AFF50"><label>50</label>
+<addr-line>
+<institution>Department of Physics and Helsinki Institute of Physics</institution>, 
+<named-content content-type="street">Gustaf Hällströmin katu 2, 00014 University of Helsinki</named-content>, 
+<country>Finland</country></addr-line></aff>
+<aff id="AFF51"><label>51</label>
+<addr-line>
+<institution>AIM, CEA, CNRS, Université Paris-Saclay, Université de Paris</institution>, 
+<named-content content-type="postcode">91191</named-content> 
+<named-content content-type="city">Gif-sur-Yvette</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF52"><label>52</label>
+<addr-line>
+<institution>Université de Genève, Département de Physique Théorique and Centre for Astroparticle Physics</institution>, 
+<named-content content-type="street">24 quai Ernest-Ansermet</named-content>, 
+<named-content content-type="postcode">1211</named-content> 
+<named-content content-type="city">Genève 4</named-content>, 
+<country>Switzerland</country></addr-line></aff>
+<aff id="AFF53"><label>53</label>
+<addr-line>
+<institution>Department of Physics</institution>, 
+<named-content content-type="postbox">P.O. Box 64</named-content>, 
+<named-content content-type="postcode">00014</named-content> 
+<named-content content-type="street">University of Helsinki</named-content>, 
+<country>Finland</country></addr-line></aff>
+<aff id="AFF54"><label>54</label>
+<addr-line>
+<institution>Helsinki Institute of Physics</institution>, 
+<named-content content-type="street">Gustaf Hällströmin katu 2, University of Helsinki</named-content>, 
+<named-content content-type="city">Helsinki</named-content>, 
+<country>Finland</country></addr-line></aff>
+<aff id="AFF55"><label>55</label>
+<addr-line>
+<institution>NOVA optical infrared instrumentation group at ASTRON</institution>, 
+<named-content content-type="street">Oude Hoogeveensedijk 4</named-content>, 
+<named-content content-type="postcode">7991PD</named-content> 
+<named-content content-type="city">Dwingeloo</named-content>, 
+<country>The Netherlands</country></addr-line></aff>
+<aff id="AFF56"><label>56</label>
+<addr-line>
+<institution>Dipartimento di Fisica “Aldo Pontremoli”, Università degli Studi di Milano</institution>, 
+<named-content content-type="street">Via Celoria 16</named-content>, 
+<named-content content-type="postcode">20133</named-content> 
+<named-content content-type="city">Milano</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF57"><label>57</label>
+<addr-line>
+<institution>INAF-IASF Milano</institution>, 
+<named-content content-type="street">Via Alfonso Corti 12</named-content>, 
+<named-content content-type="postcode">20133</named-content> 
+<named-content content-type="city">Milano</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF58"><label>58</label>
+<addr-line>
+<institution>INFN-Sezione di Milano</institution>, 
+<named-content content-type="street">Via Celoria 16</named-content>, 
+<named-content content-type="postcode">20133</named-content> 
+<named-content content-type="city">Milano</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF59"><label>59</label>
+<addr-line>
+<institution>Universität Bonn, Argelander-Institut für Astronomie</institution>, 
+<named-content content-type="street">Auf dem Hügel 71</named-content>, 
+<named-content content-type="postcode">53121</named-content> 
+<named-content content-type="city">Bonn</named-content>, 
+<country>Germany</country></addr-line></aff>
+<aff id="AFF60"><label>60</label>
+<addr-line>
+<institution>Aix-Marseille Université, CNRS, CNES, LAM</institution>, 
+<named-content content-type="city">Marseille</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF61"><label>61</label>
+<addr-line>
+<institution>Dipartimento di Fisica e Astronomia “Augusto Righi” - Alma Mater Studiorum Università di Bologna</institution>, 
+<named-content content-type="street">via Piero Gobetti 93/2</named-content>, 
+<named-content content-type="postcode">40129</named-content> 
+<named-content content-type="city">Bologna</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF62"><label>62</label>
+<addr-line>
+<institution>Department of Physics, Centre for Extragalactic Astronomy, Durham University</institution>, 
+<named-content content-type="street">South Road</named-content>, 
+<named-content content-type="postcode">DH1 3LE</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF63"><label>63</label>
+<addr-line>
+<institution>Université Côte d’Azur, Observatoire de la Côte d’Azur, CNRS, Laboratoire Lagrange</institution>, 
+<named-content content-type="street">Bd de l’Observatoire, CS 34229</named-content>, 
+<named-content content-type="postcode">06304</named-content> 
+<named-content content-type="city">Nice cedex 4</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF64"><label>64</label>
+<addr-line>
+<institution>Université Paris Cité, CNRS</institution>, 
+<named-content content-type="street">Astroparticule et Cosmologie</named-content>, 
+<named-content content-type="postcode">75013</named-content> 
+<named-content content-type="city">Paris</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF65"><label>65</label>
+<addr-line>
+<institution>Institut d’Astrophysique de Paris</institution>, 
+<named-content content-type="street">98bis Boulevard Arago</named-content>, 
+<named-content content-type="postcode">75014</named-content> 
+<named-content content-type="city">Paris</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF66"><label>66</label>
+<addr-line>
+<institution>European Space Agency/ESTEC</institution>, 
+<named-content content-type="street">Keplerlaan 1</named-content>, 
+<named-content content-type="postcode">2201 AZ</named-content> 
+<named-content content-type="city">Noordwijk</named-content>, 
+<country>The Netherlands</country></addr-line></aff>
+<aff id="AFF67"><label>67</label>
+<addr-line>
+<institution>School of Mathematics, Statistics and Physics, Newcastle University</institution>, 
+<named-content content-type="street">Herschel Building</named-content>, 
+<named-content content-type="city">Newcastle-upon-Tyne</named-content>, 
+<named-content content-type="postcode">NE1 7RU</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF68"><label>68</label>
+<addr-line>
+<institution>Department of Physics, Institute for Computational Cosmology, Durham University</institution>, 
+<named-content content-type="street">South Road</named-content>, 
+<named-content content-type="postcode">DH1 3LE</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF69"><label>69</label>
+<addr-line>
+<institution>Department of Physics and Astronomy, University of Aarhus</institution>, 
+<named-content content-type="street">Ny Munkegade 120</named-content>, 
+<named-content content-type="postcode">8000</named-content> 
+<named-content content-type="city">Aarhus C</named-content>, 
+<country>Denmark</country></addr-line></aff>
+<aff id="AFF70"><label>70</label>
+<addr-line>
+<institution>Waterloo Centre for Astrophysics, University of Waterloo</institution>, 
+<named-content content-type="city">Waterloo</named-content>, 
+<named-content content-type="state">Ontario</named-content> 
+<named-content content-type="postcode">N2L 3G1</named-content>, 
+<country>Canada</country></addr-line></aff>
+<aff id="AFF71"><label>71</label>
+<addr-line>
+<institution>Department of Physics and Astronomy, University of Waterloo</institution>, 
+<named-content content-type="city">Waterloo</named-content>, 
+<named-content content-type="state">Ontario</named-content> 
+<named-content content-type="postcode">N2L 3G1</named-content>, 
+<country>Canada</country></addr-line></aff>
+<aff id="AFF72"><label>72</label>
+<addr-line>
+<institution>Perimeter Institute for Theoretical Physics</institution>, 
+<named-content content-type="city">Waterloo</named-content>, 
+<named-content content-type="state">Ontario</named-content> 
+<named-content content-type="postcode">N2L 2Y5</named-content>, 
+<country>Canada</country></addr-line></aff>
+<aff id="AFF73"><label>73</label>
+<addr-line>
+<institution>Space Science Data Center, Italian Space Agency</institution>, 
+<named-content content-type="street">via del Politecnico snc</named-content>, 
+<named-content content-type="postcode">00133</named-content> 
+<named-content content-type="city">Roma</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF74"><label>74</label>
+<addr-line>
+<institution>Centre National d’Etudes Spatiales – Centre spatial de Toulouse</institution>, 
+<named-content content-type="street">18 avenue Edouard Belin</named-content>, 
+<named-content content-type="postcode">31401</named-content> 
+<named-content content-type="city">Toulouse Cedex 9</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF75"><label>75</label>
+<addr-line>
+<institution>Institute of Space Science</institution>, 
+<named-content content-type="street">Str. Atomistilor, nr. 409 Măgurele</named-content>, 
+<named-content content-type="city">Ilfov</named-content>, 
+<named-content content-type="postcode">077125</named-content>, 
+<country>Romania</country></addr-line></aff>
+<aff id="AFF76"><label>76</label>
+<addr-line>
+<institution>Instituto de Astrofísica de Canarias</institution>, 
+<named-content content-type="street">Calle Vía Láctea s/n</named-content>, 
+<named-content content-type="postcode">38204</named-content>, 
+<named-content content-type="city">San Cristóbal de La Laguna</named-content>, 
+<named-content content-type="state">Tenerife</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF77"><label>77</label>
+<addr-line>
+<institution>Departamento de Astrofísica, Universidad de La Laguna</institution>, 
+<named-content content-type="postcode">38206</named-content>, 
+<named-content content-type="city">La Laguna</named-content>, 
+<named-content content-type="state">Tenerife</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF78"><label>78</label>
+<addr-line>
+<institution>Dipartimento di Fisica e Astronomia “G. Galilei”, Università di Padova</institution>, 
+<named-content content-type="street">Via Marzolo 8</named-content>, 
+<named-content content-type="postcode">35131</named-content> 
+<named-content content-type="city">Padova</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF79"><label>79</label>
+<addr-line>
+<institution>Departamento de Física, FCFM, Universidad de Chile</institution>, 
+<named-content content-type="street">Blanco Encalada 2008</named-content>, 
+<named-content content-type="city">Santiago</named-content>, 
+<country>Chile</country></addr-line></aff>
+<aff id="AFF80"><label>80</label>
+<addr-line>
+<institution>Institut d’Estudis Espacials de Catalunya (IEEC), Edifici RDIT</institution>, 
+<named-content content-type="street">Campus UPC</named-content>, 
+<named-content content-type="postcode">08860</named-content> 
+<named-content content-type="city">Castelldefels, Barcelona</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF81"><label>81</label>
+<addr-line>
+<institution>Institute of Space Sciences (ICE, CSIC)</institution>, 
+<named-content content-type="street">Campus UAB, Carrer de Can Magrans, s/n</named-content>, 
+<named-content content-type="postcode">08193</named-content> 
+<named-content content-type="city">Barcelona</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF82"><label>82</label>
+<addr-line>
+<institution>Satlantis, University Science Park</institution>, 
+<named-content content-type="street">Sede Bld 48940</named-content>, 
+<named-content content-type="city">Leioa-Bilbao</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF83"><label>83</label>
+<addr-line>
+<institution>Centro de Investigaciones Energéticas, Medioambientales y Tec- nológicas (CIEMAT)</institution>, 
+<named-content content-type="street">Avenida Complutense 40</named-content>, 
+<named-content content-type="postcode">28040</named-content> 
+<named-content content-type="city">Madrid</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF84"><label>84</label>
+<addr-line>
+<institution>Instituto de Astrofísica e Ciências do Espaço, Faculdade de Ciên- cias, Universidade de Lisboa</institution>, 
+<named-content content-type="street">Tapada da Ajuda</named-content>, 
+<named-content content-type="postcode">1349-018</named-content> 
+<named-content content-type="city">Lisboa</named-content>, 
+<country>Portugal</country></addr-line></aff>
+<aff id="AFF85"><label>85</label>
+<addr-line>
+<institution>Universidad Politécnica de Cartagena, Departamento de Electrónica y Tecnología de Computadoras</institution>, 
+<named-content content-type="street">Plaza del Hospital 1</named-content>, 
+<named-content content-type="postcode">30202</named-content> 
+<named-content content-type="city">Cartagena</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF86"><label>86</label>
+<addr-line>
+<institution>Kapteyn Astronomical Institute, University of Groningen</institution>, 
+<named-content content-type="postbox">PO Box 800</named-content>, 
+<named-content content-type="postcode">9700 AV</named-content> 
+<named-content content-type="city">Groningen</named-content>, 
+<country>The Netherlands</country></addr-line></aff>
+<aff id="AFF87"><label>87</label>
+<addr-line>
+<institution>INFN-Bologna</institution>, 
+<named-content content-type="street">Via Irnerio 46</named-content>, 
+<named-content content-type="postcode">40126</named-content> 
+<named-content content-type="city">Bologna</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF88"><label>88</label>
+<addr-line>
+<institution>Infrared Processing and Analysis Center, California Institute of Technology</institution>, 
+<named-content content-type="city">Pasadena</named-content>, 
+<named-content content-type="state">CA</named-content> 
+<named-content content-type="postcode">91125</named-content>, 
+<country>USA</country></addr-line></aff>
+<aff id="AFF89"><label>89</label>
+<addr-line>
+<institution>IFPU, Institute for Fundamental Physics of the Universe</institution>, 
+<named-content content-type="street">via Beirut 2</named-content>, 
+<named-content content-type="postcode">34151</named-content> 
+<named-content content-type="city">Trieste</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF90"><label>90</label>
+<addr-line>
+<institution>INAF, Istituto di Radioastronomia</institution>, 
+<named-content content-type="street">Via Piero Gobetti 101</named-content>, 
+<named-content content-type="postcode">40129</named-content> 
+<named-content content-type="city">Bologna</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF91"><label>91</label>
+<addr-line>
+<institution>Centre de Calcul de l’IN2P3/CNRS</institution>, 
+<named-content content-type="street">21 avenue Pierre de Coubertin</named-content> 
+<named-content content-type="postcode">69627</named-content> 
+<named-content content-type="city">Villeurbanne Cedex</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF92"><label>92</label>
+<addr-line>
+<institution>INFN-Sezione di Roma, Piazzale Aldo Moro</institution>, 
+<named-content content-type="street">2 - c/o Dipartimento di Fisica, Edificio G. Marconi</named-content>, 
+<named-content content-type="postcode">00185</named-content> 
+<named-content content-type="city">Roma</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF93"><label>93</label>
+<addr-line>
+<institution>Institut für Theoretische Physik, University of Heidelberg</institution>, 
+<named-content content-type="street">Philosophenweg 16</named-content>, 
+<named-content content-type="postcode">69120</named-content> 
+<named-content content-type="city">Heidelberg</named-content>, 
+<country>Germany</country></addr-line></aff>
+<aff id="AFF94"><label>94</label>
+<addr-line>
+<institution>Université St Joseph; Faculty of Sciences</institution>, 
+<named-content content-type="city">Beirut</named-content>, 
+<country>Lebanon</country></addr-line></aff>
+<aff id="AFF95"><label>95</label>
+<addr-line>
+<institution>Junia, EPA department</institution>, 
+<named-content content-type="street">41 Bd Vauban</named-content>, 
+<named-content content-type="postcode">59800</named-content> 
+<named-content content-type="city">Lille</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF96"><label>96</label>
+<addr-line>
+<institution>SISSA, International School for Advanced Studies</institution>, 
+<named-content content-type="street">Via Bonomea 265</named-content>, 
+<named-content content-type="postcode">34136</named-content> 
+<named-content content-type="city">Trieste TS</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF97"><label>97</label>
+<addr-line>
+<institution>INFN, Sezione di Trieste</institution>, 
+<named-content content-type="street">Via Valerio 2</named-content>, 
+<named-content content-type="postcode">34127</named-content> 
+<named-content content-type="city">Trieste TS</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF98"><label>98</label>
+<addr-line>
+<institution>ICSC - Centro Nazionale di Ricerca in High Performance Computing</institution>, 
+<named-content content-type="street">Big Data e Quantum Computing, Via Magnanelli 2</named-content>, 
+<named-content content-type="city">Bologna</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF99"><label>99</label>
+<addr-line>
+<institution>Instituto de Física Teórica UAM-CSIC</institution>, 
+<named-content content-type="street">Campus de Cantoblanco</named-content>, 
+<named-content content-type="postcode">28049</named-content> 
+<named-content content-type="city">Madrid</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF100"><label>100</label>
+<addr-line>
+<institution>CERCA/ISO, Department of Physics, Case Western Reserve University</institution>, 
+<named-content content-type="street">10900 Euclid Avenue</named-content>, 
+<named-content content-type="city">Cleveland</named-content>, 
+<named-content content-type="state">OH</named-content> 
+<named-content content-type="postcode">44106</named-content>, 
+<country>USA</country></addr-line></aff>
+<aff id="AFF101"><label>101</label>
+<addr-line>
+<institution>Laboratoire Univers et Théorie, Observatoire de Paris, Université PSL, Université Paris Cité, CNRS</institution>, 
+<named-content content-type="postcode">92190</named-content> 
+<named-content content-type="city">Meudon</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF102"><label>102</label>
+<addr-line>
+<institution>Dipartimento di Fisica e Scienze della Terra, Università degli Studi di Ferrara</institution>, 
+<named-content content-type="street">Via Giuseppe Saragat 1</named-content>, 
+<named-content content-type="postcode">44122</named-content> 
+<named-content content-type="city">Ferrara</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF103"><label>103</label>
+<addr-line>
+<institution>Istituto Nazionale di Fisica Nucleare, Sezione di Ferrara</institution>, 
+<named-content content-type="street">Via Giuseppe Saragat 1</named-content>, 
+<named-content content-type="postcode">44122</named-content> 
+<named-content content-type="city">Ferrara</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF104"><label>104</label>
+<addr-line>
+<institution>Kavli Institute for the Physics and Mathematics of the Universe (WPI), University of Tokyo</institution>, 
+<named-content content-type="city">Kashiwa, Chiba</named-content> 
+<named-content content-type="postcode">277-8583</named-content>, 
+<country>Japan</country></addr-line></aff>
+<aff id="AFF105"><label>105</label>
+<addr-line>
+<institution>Dipartimento di Fisica - Sezione di Astronomia, Università di Trieste</institution>, 
+<named-content content-type="street">Via Tiepolo 11</named-content>, 
+<named-content content-type="postcode">34131</named-content> 
+<named-content content-type="city">Trieste</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF106"><label>106</label>
+<addr-line>
+<institution>Minnesota Institute for Astrophysics, University of Minnesota</institution>, 
+<named-content content-type="street">116 Church St SE</named-content>, 
+<named-content content-type="city">Minneapolis</named-content>, 
+<named-content content-type="state">MN</named-content> 
+<named-content content-type="postcode">55455</named-content>, 
+<country>USA</country></addr-line></aff>
+<aff id="AFF107"><label>107</label>
+<addr-line>
+<institution>Institute Lorentz, Leiden University</institution>, 
+<named-content content-type="street">Niels Bohrweg 2</named-content>, 
+<named-content content-type="postcode">2333 CA</named-content> 
+<named-content content-type="city">Leiden</named-content>, 
+<country>The Netherlands</country></addr-line></aff>
+<aff id="AFF108"><label>108</label>
+<addr-line>
+<institution>Institute for Astronomy, University of Hawaii</institution>, 
+<named-content content-type="street">2680 Woodlawn Drive</named-content>, 
+<named-content content-type="city">Honolulu</named-content>, 
+<named-content content-type="state">HI</named-content> 
+<named-content content-type="postcode">96822</named-content>, 
+<country>USA</country></addr-line></aff>
+<aff id="AFF109"><label>109</label>
+<addr-line>
+<institution>Department of Physics &amp; Astronomy, University of California Irvine</institution>, 
+<named-content content-type="city">Irvine</named-content> 
+<named-content content-type="state">CA</named-content> 
+<named-content content-type="postcode">92697</named-content>, 
+<country>USA</country></addr-line></aff>
+<aff id="AFF110"><label>110</label>
+<addr-line>
+<institution>Department of Astronomy &amp; Physics and Institute for Computational Astrophysics, Saint Mary’s University</institution>, 
+<named-content content-type="street">923 Robie Street, Halifax</named-content>, 
+<named-content content-type="city">Nova Scotia</named-content>, 
+<named-content content-type="postcode">B3H 3C3</named-content>, 
+<country>Canada</country></addr-line></aff>
+<aff id="AFF111"><label>111</label>
+<addr-line>
+<institution>Departamento Física Aplicada, Universidad Politécnica de Cartagena</institution>, 
+<named-content content-type="street">Campus Muralla del Mar</named-content>, 
+<named-content content-type="postcode">30202</named-content> 
+<named-content content-type="city">Cartagena</named-content>, 
+<named-content content-type="state">Murcia</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF112"><label>112</label>
+<addr-line>
+<institution>Department of Physics, Oxford University</institution>, 
+<named-content content-type="street">Keble Road</named-content>, 
+<named-content content-type="city">Oxford</named-content> 
+<named-content content-type="postcode">OX1 3RH</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF113"><label>113</label>
+<addr-line>
+<institution>Institute of Cosmology and Gravitation, University of Portsmouth</institution>, 
+<named-content content-type="city">Portsmouth</named-content> 
+<named-content content-type="postcode">PO1 3FX</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF114"><label>114</label>
+<addr-line>
+<institution>Department of Computer Science, Aalto University</institution>, 
+<named-content content-type="postbox">PO Box 15400</named-content>, 
+<named-content content-type="city">Espoo</named-content> 
+<named-content content-type="postcode">00 076</named-content>, 
+<country>Finland</country></addr-line></aff>
+<aff id="AFF115"><label>115</label>
+<addr-line>
+<institution>Ruhr University Bochum, Faculty of Physics and Astronomy, Astronomical Institute (AIRUB), German Centre for Cosmological Lensing (GCCL)</institution>, 
+<named-content content-type="postcode">44780</named-content> 
+<named-content content-type="city">Bochum</named-content>, 
+<country>Germany</country></addr-line></aff>
+<aff id="AFF116"><label>116</label>
+<addr-line>
+<institution>Univ. Grenoble Alpes, CNRS, Grenoble INP, LPSC-IN2P3</institution>, 
+<named-content content-type="street">53 Avenue des Martyrs</named-content>, 
+<named-content content-type="postcode">38000</named-content> 
+<named-content content-type="city">Grenoble</named-content>, 
+<country>France</country></addr-line></aff>
+<aff id="AFF117"><label>117</label>
+<addr-line>
+<institution>Department of Physics and Astronomy</institution>, 
+<named-content content-type="street">Vesilinnantie 5, 20014 University of Turku</named-content>, 
+<country>Finland</country></addr-line></aff>
+<aff id="AFF118"><label>118</label>
+<addr-line>
+<institution>Serco for European Space Agency (ESA)</institution>, 
+<named-content content-type="street">Camino bajo del Castillo, s/n, Urbanizacion Villafranca del Castillo, Villanueva de la Cañada</named-content>, 
+<named-content content-type="postcode">28692</named-content> 
+<named-content content-type="city">Madrid</named-content>, 
+<country>Spain</country></addr-line></aff>
+<aff id="AFF119"><label>119</label>
+<addr-line>
+<institution>ARC Centre of Excellence for Dark Matter Particle Physics</institution>, 
+<named-content content-type="city">Melbourne</named-content>, 
+<country>Australia</country></addr-line></aff>
+<aff id="AFF120"><label>120</label>
+<addr-line>
+<institution>Centre for Astrophysics &amp; Supercomputing, Swinburne University of Technology</institution>, 
+<named-content content-type="city">Victoria</named-content> 
+<named-content content-type="postcode">3122</named-content>, 
+<country>Australia</country></addr-line></aff>
+<aff id="AFF121"><label>121</label>
+<addr-line>
+<institution>School of Physics and Astronomy, Queen Mary University of London</institution>, 
+<named-content content-type="street">Mile End Road</named-content>, 
+<named-content content-type="city">London</named-content> 
+<named-content content-type="postcode">E1 4NS</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF122"><label>122</label>
+<addr-line>
+<institution>Department of Physics and Astronomy, University of the Western Cape</institution>, 
+<named-content content-type="street">Bellville</named-content>, 
+<named-content content-type="city">Cape Town</named-content> 
+<named-content content-type="postcode">7535</named-content>, 
+<country>South Africa</country></addr-line></aff>
+<aff id="AFF123"><label>123</label>
+<addr-line>
+<institution>ICTP South American Institute for Fundamental Research, Instituto de Física Teórica, Universidade Estadual Paulista</institution>, 
+<named-content content-type="city">São Paulo</named-content>, 
+<country>Brazil</country></addr-line></aff>
+<aff id="AFF124"><label>124</label>
+<addr-line>
+<institution>Oskar Klein Centre for Cosmoparticle Physics, Department of Physics, Stockholm University</institution>, 
+<named-content content-type="city">Stockholm</named-content> 
+<named-content content-type="postcode">106 91</named-content>, 
+<country>Sweden</country></addr-line></aff>
+<aff id="AFF125"><label>125</label>
+<addr-line>
+<institution>Astrophysics Group, Blackett Laboratory, Imperial College London</institution>, 
+<named-content content-type="city">London</named-content> 
+<named-content content-type="postcode">SW7 2AZ</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF126"><label>126</label>
+<addr-line>
+<institution>INAF-Osservatorio Astrofisico di Arcetri</institution>, 
+<named-content content-type="street">Largo E. Fermi 5</named-content>, 
+<named-content content-type="postcode">50125</named-content> 
+<named-content content-type="city">Firenze</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF127"><label>127</label>
+<addr-line>
+<institution>Dipartimento di Fisica, Sapienza Università di Roma</institution>, 
+<named-content content-type="street">Piazzale Aldo Moro 2</named-content>, 
+<named-content content-type="postcode">00185</named-content> 
+<named-content content-type="city">Roma</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF128"><label>128</label>
+<addr-line>
+<institution>Centro de Astrofísica da Universidade do Porto</institution>, 
+<named-content content-type="street">Rua das Estrelas</named-content>, 
+<named-content content-type="postcode">4150-762</named-content> 
+<named-content content-type="city">Porto</named-content>, 
+<country>Portugal</country></addr-line></aff>
+<aff id="AFF129"><label>129</label>
+<addr-line>
+<institution>Dipartimento di Fisica, Università di Roma Tor Vergata</institution>, 
+<named-content content-type="street">Via della Ricerca Scientifica 1</named-content>, 
+<named-content content-type="city">Roma</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF130"><label>130</label>
+<addr-line>
+<institution>INFN</institution>, 
+<named-content content-type="street">Sezione di Roma 2, Via della Ricerca Scientifica 1</named-content>, 
+<named-content content-type="city">Roma</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF131"><label>131</label>
+<addr-line>
+<institution>Institute of Astronomy, University of Cambridge</institution>, 
+<named-content content-type="street">Madingley Road</named-content>, 
+<named-content content-type="city">Cambridge</named-content> 
+<named-content content-type="postcode">CB3 0HA</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF132"><label>132</label>
+<addr-line>
+<institution>Department of Astrophysics, University of Zurich</institution>, 
+<named-content content-type="street">Winterthur-erstrasse 190</named-content>, 
+<named-content content-type="postcode">8057</named-content> 
+<named-content content-type="city">Zurich</named-content>, 
+<country>Switzerland</country></addr-line></aff>
+<aff id="AFF133"><label>133</label>
+<addr-line>
+<institution>Dipartimento di Fisica, Università degli studi di Genova, and INFN-Sezione di Genova</institution>, 
+<named-content content-type="street">via Dodecaneso 33</named-content>, 
+<named-content content-type="postcode">16146</named-content> 
+<named-content content-type="city">Genova</named-content>, 
+<country>Italy</country></addr-line></aff>
+<aff id="AFF134"><label>134</label>
+<addr-line>
+<institution>Theoretical astrophysics, Department of Physics and Astronomy, Uppsala University</institution>, 
+<named-content content-type="postbox">Box 515</named-content>, 
+<named-content content-type="postcode">751 20</named-content> 
+<named-content content-type="city">Uppsala</named-content>, 
+<country>Sweden</country></addr-line></aff>
+<aff id="AFF135"><label>135</label>
+<addr-line>
+<institution>Department of Physics and Astronomy, University College London</institution>, 
+<named-content content-type="street">Gower Street</named-content>, 
+<named-content content-type="city">London</named-content> 
+<named-content content-type="postcode">WC1E 6BT</named-content>, 
+<country>UK</country></addr-line></aff>
+<aff id="AFF136"><label>136</label>
+<addr-line>
+<institution>Department of Astrophysical Sciences, Peyton Hall, Princeton University</institution>, 
+<named-content content-type="city">Princeton</named-content>, 
+<named-content content-type="state">NJ</named-content> 
+<named-content content-type="postcode">08544</named-content>, 
+<country>USA</country></addr-line></aff>
+<aff id="AFF137"><label>137</label>
+<addr-line>
+<institution>Niels Bohr Institute, University of Copenhagen</institution>, 
+<named-content content-type="street">Jagtvej 128</named-content>, 
+<named-content content-type="postcode">2200</named-content> 
+<named-content content-type="city">Copenhagen</named-content>, 
+<country>Denmark</country></addr-line></aff>
+<aff id="AFF138"><label>138</label>
+<addr-line>
+<institution>Center for Cosmology and Particle Physics, Department of Physics, New York University</institution>, 
+<named-content content-type="city">New York</named-content>, 
+<named-content content-type="state">NY</named-content> 
+<named-content content-type="postcode">10003</named-content>, 
+<country>USA</country></addr-line></aff>
+<aff id="AFF139"><label>139</label>
+<addr-line>
+<institution>Center for Computational Astrophysics, Flatiron Institute</institution>, 
+<named-content content-type="street">162 5th Avenue</named-content>, 
+<named-content content-type="postcode">10010</named-content>, 
+<named-content content-type="city">New York</named-content>, 
+<named-content content-type="state">NY</named-content>, 
+<country>USA</country></addr-line></aff>
+<author-notes>
+<fn id="FN1"><label>★</label><p>Corresponding author; <email>alain.blanchard@irap.omp.eu</email></p></fn>
+</author-notes><pub-date pub-type="final"><day>30</day><month>09</month><year>2024</year></pub-date><pub-date pub-type="epub"><day>30</day><month>09</month><year>2024</year></pub-date>
+<pub-date pub-type="ppub"><month>10</month><year>2024</year></pub-date><volume>690</volume><issue-id pub-id-type="publisher-id">aa/2024/10</issue-id><elocation-id>A30</elocation-id>
+<history>
+<date date-type="received">
+<day>14</day>
+<month>4</month>
+<year>2024</year>
+</date>
+<date date-type="accepted">
+<day>8</day>
+<month>7</month>
+<year>2024</year>
+</date>
+</history>
+<permissions>
+<copyright-statement>© The Authors 2024</copyright-statement>
+<copyright-year>2024</copyright-year>
+<copyright-holder>The Authors</copyright-holder>
+<license license-type="open-access">
+<license-p content-type="cc-by-4.0">Open Access article, <ext-link ext-link-type="uri" xlink:href="https://www.edpsciences.org/en/">published by EDP Sciences</ext-link>, under the terms of the Creative Commons Attribution License (<ext-link ext-link-type="uri" xlink:href="https://creativecommons.org/licenses/by/4.0">https://creativecommons.org/licenses/by/4.0</ext-link>), which permits unrestricted use, distribution, and reproduction in any medium, provided the original work is properly cited.</license-p>
+<license-p content-type="oa-funding-note" specific-use="s2o">This article is published in open access under the <ext-link ext-link-type="uri" xlink:href="https://www.aanda.org/subscribe-to-open-faqs">Subscribe to Open model</ext-link>. <ext-link ext-link-type="email" xlink:href="mailto:subscribers@edpsciences.org">Subscribe to A&amp;A</ext-link> to support open access publication.</license-p>
+</license>
+</permissions><self-uri content-type="abstract" xlink:href="https://www.aanda.org/articles/aa/abs/2024/10/aa50368-24/aa50368-24.html"/><self-uri content-type="full_html" xlink:href="https://www.aanda.org/articles/aa/full_html/2024/10/aa50368-24/aa50368-24.html"/><self-uri content-type="pdf" xlink:href="https://www.aanda.org/articles/aa/pdf/2024/10/aa50368-24.pdf"/>
+<abstract xml:lang="en">
+<p>Future data provided by the <italic>Euclid</italic> mission will allow us to better understand the cosmic history of the Universe. A metric of its performance is the figure-of-merit (FoM) of dark energy, usually estimated with Fisher forecasts. The expected FoM has previously been estimated taking into account the two main probes of <italic>Euclid</italic>, namely the three-dimensional clustering of the spectroscopic galaxy sample, and the so-called 3×2pt signal from the photometric sample (i.e., the weak lensing signal, the galaxy clustering, and their cross-correlation). So far, these two probes have been treated as independent. In this paper, we introduce a new observable given by the ratio of the (angular) two-point correlation function of galaxies from the two surveys. For identical (normalised) selection functions, this observable is unaffected by sampling noise, and its variance is solely controlled by Poisson noise. We present forecasts for <italic>Euclid</italic> where this multi-tracer method is applied and is particularly relevant because the two surveys will cover the same area of the sky. This method allows for the exploitation of the combination of the spectroscopic and photometric samples. When the correlation between this new observable and the other probes is not taken into account, a significant gain is obtained in the FoM, as well as in the constraints on other cosmological parameters. The benefit is more pronounced for a commonly investigated modified gravity model, namely the <italic>γ</italic> parametrisation of the growth factor. However, the correlation between the different probes is found to be significant and hence the actual gain is uncertain. We present various strategies for circumventing this issue and still extract useful information from the new observable.</p>
+</abstract>
+<kwd-group xml:lang="en">
+<title>Key words</title>
+<kwd>cosmological parameters</kwd>
+<kwd>dark energy</kwd>
+<kwd>large-scale structure of Universe</kwd>
+</kwd-group>
+<counts>
+<fig-count count="7"/>
+<table-count count="4"/>
+<equation-count count="73"/>
+<ref-count count="44"/>
+<page-count count="16"/>
+</counts>
+<custom-meta-group>
+<custom-meta>
+<meta-name>idline</meta-name>
+<meta-value>A&amp;A, 690, A30 (2024)</meta-value>
+</custom-meta>
+<custom-meta>
+<meta-name>open-access</meta-name>
+<meta-value>yes</meta-value>
+</custom-meta>
+<custom-meta>
+<meta-name>cover_date</meta-name>
+<meta-value>October 2024</meta-value>
+</custom-meta>
+<custom-meta>
+<meta-name>first_month</meta-name>
+<meta-value>10</meta-value>
+</custom-meta>
+<custom-meta>
+<meta-name>last_month</meta-name>
+<meta-value>10</meta-value>
+</custom-meta>
+<custom-meta>
+<meta-name>first_year</meta-name>
+<meta-value>2024</meta-value>
+</custom-meta>
+<custom-meta>
+<meta-name>last_year</meta-name>
+<meta-value>2024</meta-value>
+</custom-meta>
+<custom-meta><meta-name>transformative_agreement</meta-name><meta-value>national-agreement-fr_2024</meta-value></custom-meta></custom-meta-group>
+</article-meta>
+</front>
+
+<back>
+<ack>
+<title>Acknowledgements</title>
+<p>S. I. thanks the Centre national d’études spatiales (CNES) which supports his postdoctoral research contract. The Euclid Consortium acknowledges the European Space Agency and a number of agencies and institutes that have supported the development of <italic>Euclid</italic>, in particular the Academy of Finland, the Agenzia Spaziale Italiana, the Belgian Science Policy, the Canadian Euclid Consortium, the French Centre National d’Etudes Spatiales, the Deutsches Zentrum für Luft- und Raumfahrt, the Danish Space Research Institute, the Fundação para a Ciência e a Tecnologia, the Ministerio de Ciencia e Innovación, the National Aeronautics and Space Administration, the National Astronomical Observatory of Japan, the Netherlandse Onder-zoekschool Voor Astronomie, the Norwegian Space Agency, the Romanian Space Agency, the State Secretariat for Education, Research and Innovation (SERI) at the Swiss Space Office (SSO), and the United Kingdom Space Agency. A complete and detailed list is available on the <italic>Euclid</italic> web site (<ext-link ext-link-type="uri" xlink:href="http://www.euclid-ec.org">http://www.euclid-ec.org</ext-link>)..</p>
+</ack>
+
+<ref-list>
+<title>References</title>
+<ref id="R1"><mixed-citation publication-type="journal"><string-name><surname>Abbott</surname>, <given-names>T. M. C.</given-names></string-name>, <string-name><surname>Aguena</surname>, <given-names>M.</given-names></string-name>, <string-name><surname>Alarcon</surname>, <given-names>A.</given-names></string-name>, et al. <year>2022</year>, <source>Phys. Rev. D</source>, <volume>105</volume>, <fpage>023520</fpage></mixed-citation></ref>
+<ref id="R2"><mixed-citation publication-type="journal"><string-name><surname>Abramo</surname>, <given-names>L. R.</given-names></string-name>, <string-name><surname>Dinarte Ferri</surname>, <given-names>J. V.</given-names></string-name>, <string-name><surname>Tashiro</surname>, <given-names>I. L.</given-names></string-name>, &amp; <string-name><surname>Loureiro</surname>, <given-names>A.</given-names></string-name> <year>2022</year>, <source>J. Cosmology Astropart. Phys.</source>, <volume>8</volume>, <fpage>073</fpage></mixed-citation></ref>
+<ref id="R3"><mixed-citation publication-type="web"><string-name><surname>Albrecht</surname>, <given-names>A.</given-names></string-name>, <string-name><surname>Bernstein</surname>, <given-names>G.</given-names></string-name>, <string-name><surname>Cahn</surname>, <given-names>R.</given-names></string-name>, et al. <year>2006</year>, <source>arXiv e-prints</source> [<ext-link ext-link-type="uri" xlink:href="https://arxiv.org/abs/astro-ph/0609591">arXiv:astro-ph/0609591</ext-link>]</mixed-citation></ref>
+<ref id="R4"><mixed-citation publication-type="journal"><string-name><surname>Alcock</surname>, <given-names>C.</given-names></string-name>, &amp; <string-name><surname>Paczynski</surname>, <given-names>B.</given-names></string-name> <year>1979</year>, <source>Nature</source>, <volume>281</volume>, <fpage>358</fpage></mixed-citation></ref>
+<ref id="R5"><mixed-citation publication-type="journal"><string-name><surname>Alimi</surname>, <given-names>J. M.</given-names></string-name>, <string-name><surname>Valls-Gabaud</surname>, <given-names>D.</given-names></string-name>, &amp; <string-name><surname>Blanchard</surname>, <given-names>A.</given-names></string-name> <year>1988</year>, <source>A&amp;A</source>, <volume>206</volume>, <fpage>L11</fpage></mixed-citation></ref>
+<ref id="R6"><mixed-citation publication-type="journal"><string-name><surname>Amendola</surname>, <given-names>L.</given-names></string-name>, <string-name><surname>Appleby</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Avgoustidis</surname>, <given-names>A.</given-names></string-name>, et al. <year>2018</year>, <source>Liv. Rev. Relativ.</source>, <volume>21</volume>, <fpage>2</fpage></mixed-citation></ref>
+<ref id="R7"><mixed-citation publication-type="journal"><string-name><surname>Aubourg</surname>, <given-names>É.</given-names></string-name>, <string-name><surname>Bailey</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Bautista</surname>, <given-names>J. E.</given-names></string-name>, et al. <year>2015</year>, <source>Phys. Rev. D</source>, <volume>92</volume>, <fpage>123516</fpage></mixed-citation></ref>
+<ref id="R8"><mixed-citation publication-type="journal"><string-name><surname>Blanchard</surname>, <given-names>A.</given-names></string-name> <year>2022</year>, <source>Universe</source>, <volume>8</volume>, <fpage>479</fpage></mixed-citation></ref>
+<ref id="R9"><mixed-citation publication-type="journal"><string-name><surname>Chevallier</surname>, <given-names>M.</given-names></string-name>, &amp; <string-name><surname>Polarski</surname>, <given-names>D.</given-names></string-name> <year>2001</year>, <source>Int. J. Mod. Phys.</source>, <volume>D10</volume>, <fpage>213</fpage></mixed-citation></ref>
+<ref id="R10"><mixed-citation publication-type="journal"><string-name><surname>Cropper</surname>, <given-names>M.</given-names></string-name>, <string-name><surname>Pottinger</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Azzollini</surname>, <given-names>R.</given-names></string-name>, et al. <year>2018</year>, <source>SPIE</source>, <volume>10698</volume>, <fpage>709</fpage></mixed-citation></ref>
+<ref id="R11"><mixed-citation publication-type="journal"><string-name><surname>Eisenstein</surname>, <given-names>D. J.</given-names></string-name>, <string-name><surname>Zehavi</surname>, <given-names>I.</given-names></string-name>, <string-name><surname>Hogg</surname>, <given-names>D. W.</given-names></string-name>, et al. <year>2005</year>, <source>ApJ</source>, <volume>633</volume>, <fpage>560</fpage></mixed-citation></ref>
+<ref id="R12"><mixed-citation publication-type="journal"><collab>Euclid Collaboration</collab> (<string-name><surname>Blanchard</surname>, <given-names>A.</given-names></string-name>, et al.) <year>2020</year>, <source>A&amp;A</source>, <volume>642</volume>, <fpage>A191</fpage></mixed-citation></ref>
+<ref id="R13"><mixed-citation publication-type="web"><collab>Euclid Collaboration</collab> (<string-name><surname>Cropper</surname>, <given-names>M.</given-names></string-name>, et al.) <year>2024</year>a, <source>A&amp;A</source>, submitted [<ext-link ext-link-type="uri" xlink:href="https://arxiv.org/abs/2405.13492">arXiv:2405.13492</ext-link>]</mixed-citation></ref>
+<ref id="R14"><mixed-citation publication-type="web"><collab>Euclid Collaboration</collab> (<string-name><surname>Jahnke</surname>, <given-names>K.</given-names></string-name>, et al.) <year>2024</year>b, <source>A&amp;A</source>, in press, <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1051/0004-6361/202450786">https://doi.org/10.1051/0004-6361/202450786</ext-link></mixed-citation></ref>
+<ref id="R15"><mixed-citation publication-type="web"><collab>Euclid Collaboration</collab> (<string-name><surname>Mellier</surname>, <given-names>Y.</given-names></string-name>, et al.) <year>2024</year>c, <source>A&amp;A</source>, in press, <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1051/0004-6361/202450010">https://doi.org/10.1051/0004-6361/202450010</ext-link></mixed-citation></ref>
+<ref id="R16"><mixed-citation publication-type="journal"><string-name><surname>Hamaus</surname>, <given-names>N.</given-names></string-name>, <string-name><surname>Seljak</surname>, <given-names>U.</given-names></string-name>, <string-name><surname>Desjacques</surname>, <given-names>V.</given-names></string-name>, <string-name><surname>Smith</surname>, <given-names>R. E.</given-names></string-name>, &amp; <string-name><surname>Baldauf</surname>, <given-names>T.</given-names></string-name> <year>2010</year>, <source>Phys. Rev. D</source>, <volume>82</volume>, <fpage>043515</fpage></mixed-citation></ref>
+<ref id="R17"><mixed-citation publication-type="journal"><string-name><surname>Heymans</surname>, <given-names>C.</given-names></string-name>, <string-name><surname>Tröster</surname>, <given-names>T.</given-names></string-name>, <string-name><surname>Asgari</surname>, <given-names>M.</given-names></string-name>, et al. <year>2021</year>, <source>A&amp;A</source>, <volume>646</volume>, <fpage>A140</fpage></mixed-citation></ref>
+<ref id="R18"><mixed-citation publication-type="journal"><string-name><surname>Hu</surname>, <given-names>W.</given-names></string-name>, &amp; <string-name><surname>Sawicki</surname>, <given-names>I.</given-names></string-name> <year>2007</year>, <source>Phys. Rev. D</source>, <volume>76</volume>, <fpage>104043</fpage></mixed-citation></ref>
+<ref id="R19"><mixed-citation publication-type="journal"><string-name><surname>Kilbinger</surname>, <given-names>M.</given-names></string-name> <year>2015</year>, <source>Rep. Prog. Phys.</source>, <volume>78</volume>, <fpage>086901</fpage></mixed-citation></ref>
+<ref id="R20"><mixed-citation publication-type="journal"><string-name><surname>Lahav</surname>, <given-names>O.</given-names></string-name>, <string-name><surname>Lilje</surname>, <given-names>P. ?.</given-names></string-name>, <string-name><surname>Primack</surname>, <given-names>J. R.</given-names></string-name>, &amp; <string-name><surname>Rees</surname>, <given-names>M. J.</given-names></string-name> <year>1991</year>, <source>MNRAS</source>, <volume>251</volume>, <fpage>128</fpage></mixed-citation></ref>
+<ref id="R21"><mixed-citation publication-type="web"><string-name><surname>Laureijs</surname>, <given-names>R.</given-names></string-name>, <string-name><surname>Amiaux</surname>, <given-names>J.</given-names></string-name>, <string-name><surname>Arduini</surname>, <given-names>S.</given-names></string-name>, et al. <year>2011</year>, <source>arXiv e-prints</source> [<ext-link ext-link-type="uri" xlink:href="https://arxiv.org/abs/1110.3193">arXiv:1110.3193</ext-link>]</mixed-citation></ref>
+<ref id="R22"><mixed-citation publication-type="web"><string-name><surname>Lesgourgues</surname>, <given-names>J.</given-names></string-name> <year>2011</year>, <source>arXiv e-prints</source> [<ext-link ext-link-type="uri" xlink:href="https://arxiv.org/abs/1104.2932">arXiv:1104.2932</ext-link>]</mixed-citation></ref>
+<ref id="R23"><mixed-citation publication-type="journal"><string-name><surname>Lewis</surname>, <given-names>A.</given-names></string-name>, <string-name><surname>Challinor</surname>, <given-names>A.</given-names></string-name>, &amp; <string-name><surname>Lasenby</surname>, <given-names>A.</given-names></string-name> <year>2000</year>, <source>ApJ</source>, <volume>538</volume>, <fpage>473</fpage></mixed-citation></ref>
+<ref id="R24"><mixed-citation publication-type="journal"><string-name><surname>Linder</surname>, <given-names>E. V.</given-names></string-name> <year>2003</year>, <source>Phys. Rev. Lett.</source>, <volume>90</volume>, <fpage>091301</fpage></mixed-citation></ref>
+<ref id="R25"><mixed-citation publication-type="journal"><string-name><surname>Linder</surname>, <given-names>E. V.</given-names></string-name> <year>2005</year>, <source>Phys. Rev. D</source>, <volume>72</volume>, <fpage>043529</fpage></mixed-citation></ref>
+<ref id="R26"><mixed-citation publication-type="journal"><string-name><surname>LoVerde</surname>, <given-names>M.</given-names></string-name>, &amp; <string-name><surname>Afshordi</surname>, <given-names>N.</given-names></string-name> <year>2008</year>, <source>Phys. Rev. D</source>, <volume>78</volume>, <fpage>123506</fpage></mixed-citation></ref>
+<ref id="R27"><mixed-citation publication-type="web"><string-name><surname>Ly</surname>, <given-names>A.</given-names></string-name>, <string-name><surname>Marsman</surname>, <given-names>M.</given-names></string-name>, <string-name><surname>Verhagen</surname>, <given-names>J.</given-names></string-name>, <string-name><surname>Grasman</surname>, <given-names>R.</given-names></string-name>, &amp; <string-name><surname>Wagenmakers</surname>, <given-names>E.-J.</given-names></string-name> <year>2017</year>, <source>arXiv e-prints</source> [<ext-link ext-link-type="uri" xlink:href="https://arxiv.org/abs/1705.01064">arXiv: 1705.01064</ext-link>]</mixed-citation></ref>
+<ref id="R28"><mixed-citation publication-type="journal"><string-name><surname>Maciaszek</surname>, <given-names>T.</given-names></string-name>, <string-name><surname>Ealet</surname>, <given-names>A.</given-names></string-name>, <string-name><surname>Gillard</surname>, <given-names>W.</given-names></string-name>, et al. <year>2022</year>, <source>SPIE Conf. Ser.</source>, <volume>12180</volume>, <fpage>121801K</fpage></mixed-citation></ref>
+<ref id="R29"><mixed-citation publication-type="journal"><string-name><surname>McDonald</surname>, <given-names>P.</given-names></string-name>, &amp; <string-name><surname>Seljak</surname>, <given-names>U.</given-names></string-name> <year>2009</year>, <source>J. Cosmology Astropart. Phys.</source>, <volume>10</volume>, <fpage>007</fpage></mixed-citation></ref>
+<ref id="R30"><mixed-citation publication-type="journal"><string-name><surname>Passaglia</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Manzotti</surname>, <given-names>A.</given-names></string-name>, &amp; <string-name><surname>Dodelson</surname>, <given-names>S.</given-names></string-name> <year>2017</year>, <source>Phys. Rev. D</source>, <volume>95</volume>, <fpage>123508</fpage></mixed-citation></ref>
+<ref id="R31"><mixed-citation publication-type="journal"><string-name><surname>Percival</surname>, <given-names>W. J.</given-names></string-name>, &amp; <string-name><surname>White</surname>, <given-names>M.</given-names></string-name> <year>2009</year>, <source>MNRAS</source>, <volume>393</volume>, <fpage>297</fpage></mixed-citation></ref>
+<ref id="R32"><mixed-citation publication-type="journal"><string-name><surname>Pozzetti</surname>, <given-names>L.</given-names></string-name>, <string-name><surname>Hirata</surname>, <given-names>C. M.</given-names></string-name>, <string-name><surname>Geach</surname>, <given-names>J. E.</given-names></string-name>, et al. <year>2016</year>, <source>A&amp;A</source>, <volume>590</volume>, <fpage>A3</fpage></mixed-citation></ref>
+<ref id="R33"><mixed-citation publication-type="journal"><string-name><surname>Seljak</surname>, <given-names>U.</given-names></string-name> <year>2009</year>, <source>Phys. Rev. Lett.</source>, <volume>102</volume>, <fpage>021302</fpage></mixed-citation></ref>
+<ref id="R34"><mixed-citation publication-type="journal"><string-name><surname>Seljak</surname>, <given-names>U.</given-names></string-name>, <string-name><surname>Hamaus</surname>, <given-names>N.</given-names></string-name>, &amp; <string-name><surname>Desjacques</surname>, <given-names>V.</given-names></string-name> <year>2009</year>, <source>Phys. Rev. Lett.</source>, <volume>103</volume>, <fpage>091303</fpage></mixed-citation></ref>
+<ref id="R35"><mixed-citation publication-type="journal"><string-name><surname>Sugiyama</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Miyatake</surname>, <given-names>H.</given-names></string-name>, <string-name><surname>More</surname>, <given-names>S.</given-names></string-name>, et al. <year>2023</year>, <source>Phys. Rev. D</source>, <volume>108</volume>, <fpage>123521</fpage></mixed-citation></ref>
+<ref id="R36"><mixed-citation publication-type="journal"><string-name><surname>Tanidis</surname>, <given-names>K.</given-names></string-name>, &amp; <string-name><surname>Camera</surname>, <given-names>S.</given-names></string-name> <year>2021</year>, <source>MNRAS</source>, <volume>502</volume>, <fpage>2952</fpage></mixed-citation></ref>
+<ref id="R37"><mixed-citation publication-type="journal"><string-name><surname>Tanidis</surname>, <given-names>K.</given-names></string-name>, <string-name><surname>Cardone</surname>, <given-names>V. F.</given-names></string-name>, <string-name><surname>Martinelli</surname>, <given-names>M.</given-names></string-name>, et al. <year>2024</year>, <source>A&amp;A</source>, <volume>683</volume>, <fpage>A17</fpage></mixed-citation></ref>
+<ref id="R38"><mixed-citation publication-type="journal"><string-name><surname>Taylor</surname>, <given-names>P. L.</given-names></string-name>, &amp; <string-name><surname>Markovic</surname>, <given-names>K.</given-names></string-name> <year>2022</year>, <source>Phys. Rev. D</source>, <volume>106</volume>, <fpage>063536</fpage></mixed-citation></ref>
+<ref id="R39"><mixed-citation publication-type="journal"><string-name><surname>Tessore</surname>, <given-names>N.</given-names></string-name> <year>2017</year>, <source>MNRAS</source>, <volume>471</volume>, <fpage>L57</fpage></mixed-citation></ref>
+<ref id="R40"><mixed-citation publication-type="journal"><string-name><surname>Tutusaus</surname>, <given-names>I.</given-names></string-name>, <string-name><surname>Martinelli</surname>, <given-names>M.</given-names></string-name>, <string-name><surname>Cardone</surname>, <given-names>V. F.</given-names></string-name>, et al. <year>2020</year>, <source>A&amp;A</source>, <volume>643</volume>, <fpage>A70</fpage></mixed-citation></ref>
+<ref id="R41"><mixed-citation publication-type="journal"><string-name><surname>Wang</surname>, <given-names>Y.</given-names></string-name> <year>2008</year>, <source>Phys. Rev. D</source>, <volume>77</volume>, <fpage>123525</fpage></mixed-citation></ref>
+<ref id="R42"><mixed-citation publication-type="journal"><string-name><surname>Wang</surname>, <given-names>Y.</given-names></string-name>, &amp; <string-name><surname>Zhao</surname>, <given-names>G.-B.</given-names></string-name> <year>2020</year>, <source>Res. Astron. Astrophys.</source>, <volume>20</volume>, <fpage>158</fpage></mixed-citation></ref>
+<ref id="R43"><mixed-citation publication-type="journal"><string-name><surname>Wang</surname>, <given-names>M. S.</given-names></string-name>, <string-name><surname>Avila</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Bianchi</surname>, <given-names>D.</given-names></string-name>, <string-name><surname>Crittenden</surname>, <given-names>R.</given-names></string-name>, &amp; <string-name><surname>Percival</surname>, <given-names>W. J.</given-names></string-name> <year>2020</year>, <source>JCAP</source> <volume>10</volume>, <fpage>022</fpage></mixed-citation></ref>
+<ref id="R44"><mixed-citation publication-type="journal"><string-name><surname>Yahia-Cherif</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Blanchard</surname>, <given-names>A.</given-names></string-name>, <string-name><surname>Camera</surname>, <given-names>S.</given-names></string-name>, et al. <year>2021</year>, <source>A&amp;A</source>, <volume>649</volume>, <fpage>A52</fpage></mixed-citation></ref>
+</ref-list>
+
+</back>
+</article>

--- a/tests/stubdata/input/jats_edp_null_nested_collab_aa50368-24.xml
+++ b/tests/stubdata/input/jats_edp_null_nested_collab_aa50368-24.xml
@@ -1305,946 +1305,946 @@
 </contrib-group>
 <aff id="AFF1"><label>1</label>
 <addr-line>
-<institution>Institut de Recherche en Astrophysique et Planétologie (IRAP), Université de Toulouse, CNRS, UPS, CNES</institution>, 
-<named-content content-type="street">14 Av. Edouard Belin</named-content>, 
-<named-content content-type="postcode">31400</named-content> 
-<named-content content-type="city">Toulouse</named-content>, 
+<institution>Institut de Recherche en Astrophysique et Planétologie (IRAP), Université de Toulouse, CNRS, UPS, CNES</institution>,
+<named-content content-type="street">14 Av. Edouard Belin</named-content>,
+<named-content content-type="postcode">31400</named-content>
+<named-content content-type="city">Toulouse</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF2"><label>2</label>
 <addr-line>
-<institution>Université Paris-Saclay, CNRS/IN2P3, IJCLab</institution>, 
-<named-content content-type="postcode">91405</named-content> 
-<named-content content-type="city">Orsay</named-content>, 
+<institution>Université Paris-Saclay, CNRS/IN2P3, IJCLab</institution>,
+<named-content content-type="postcode">91405</named-content>
+<named-content content-type="city">Orsay</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF3"><label>3</label>
 <addr-line>
-<institution>School of Mathematics and Physics, University of Surrey</institution>, 
-<named-content content-type="city">Guildford</named-content>, 
-<named-content content-type="state">Surrey</named-content>, 
-<named-content content-type="postcode">GU2 7XH</named-content>, 
+<institution>School of Mathematics and Physics, University of Surrey</institution>,
+<named-content content-type="city">Guildford</named-content>,
+<named-content content-type="state">Surrey</named-content>,
+<named-content content-type="postcode">GU2 7XH</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF4"><label>4</label>
 <addr-line>
-<institution>INAF-Osservatorio Astronomico di Brera</institution>, 
-<named-content content-type="street">Via Brera 28</named-content>, 
-<named-content content-type="postcode">20122</named-content> 
-<named-content content-type="city">Milano</named-content>, 
+<institution>INAF-Osservatorio Astronomico di Brera</institution>,
+<named-content content-type="street">Via Brera 28</named-content>,
+<named-content content-type="postcode">20122</named-content>
+<named-content content-type="city">Milano</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF5"><label>5</label>
 <addr-line>
-<institution>INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna</institution>, 
-<named-content content-type="street">Via Piero Gobetti 93/3</named-content>, 
-<named-content content-type="postcode">40129</named-content> 
-<named-content content-type="city">Bologna</named-content>, 
+<institution>INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna</institution>,
+<named-content content-type="street">Via Piero Gobetti 93/3</named-content>,
+<named-content content-type="postcode">40129</named-content>
+<named-content content-type="city">Bologna</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF6"><label>6</label>
 <addr-line>
-<institution>Université Paris-Saclay, Université Paris Cité, CEA, CNRS, AIM</institution>, 
-<named-content content-type="postcode">91191</named-content> 
-<named-content content-type="city">Gif-sur-Yvette</named-content>, 
+<institution>Université Paris-Saclay, Université Paris Cité, CEA, CNRS, AIM</institution>,
+<named-content content-type="postcode">91191</named-content>
+<named-content content-type="city">Gif-sur-Yvette</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF7"><label>7</label>
 <addr-line>
-<institution>Dipartimento di Fisica e Astronomia, Università di Bologna</institution>, 
-<named-content content-type="street">Via Gobetti 93/2</named-content>, 
-<named-content content-type="postcode">40129</named-content> 
-<named-content content-type="city">Bologna</named-content>, 
+<institution>Dipartimento di Fisica e Astronomia, Università di Bologna</institution>,
+<named-content content-type="street">Via Gobetti 93/2</named-content>,
+<named-content content-type="postcode">40129</named-content>
+<named-content content-type="city">Bologna</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF8"><label>8</label>
 <addr-line>
-<institution>INFN-Sezione di Bologna</institution>, 
-<named-content content-type="street">Viale Berti Pichat 6/2</named-content>, 
-<named-content content-type="postcode">40127</named-content> 
-<named-content content-type="city">Bologna</named-content>, 
+<institution>INFN-Sezione di Bologna</institution>,
+<named-content content-type="street">Viale Berti Pichat 6/2</named-content>,
+<named-content content-type="postcode">40127</named-content>
+<named-content content-type="city">Bologna</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF9"><label>9</label>
 <addr-line>
-<institution>Max Planck Institute for Extraterrestrial Physics</institution>, 
-<named-content content-type="street">Giessenbachstr. 1</named-content>, 
-<named-content content-type="postcode">85748</named-content> 
-<named-content content-type="city">Garching</named-content>, 
+<institution>Max Planck Institute for Extraterrestrial Physics</institution>,
+<named-content content-type="street">Giessenbachstr. 1</named-content>,
+<named-content content-type="postcode">85748</named-content>
+<named-content content-type="city">Garching</named-content>,
 <country>Germany</country></addr-line></aff>
 <aff id="AFF10"><label>10</label>
 <addr-line>
-<institution>INAF-Osservatorio Astrofisico di Torino</institution>, 
-<named-content content-type="street">Via Osservatorio 20</named-content>, 
-<named-content content-type="postcode">10025</named-content> 
-<named-content content-type="city">Pino Torinese (TO)</named-content>, 
+<institution>INAF-Osservatorio Astrofisico di Torino</institution>,
+<named-content content-type="street">Via Osservatorio 20</named-content>,
+<named-content content-type="postcode">10025</named-content>
+<named-content content-type="city">Pino Torinese (TO)</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF11"><label>11</label>
 <addr-line>
-<institution>Dipartimento di Fisica, Università di Genova</institution>, 
-<named-content content-type="street">Via Dodecaneso 33</named-content>, 
-<named-content content-type="postcode">16146</named-content>, 
-<named-content content-type="city">Genova</named-content>, 
+<institution>Dipartimento di Fisica, Università di Genova</institution>,
+<named-content content-type="street">Via Dodecaneso 33</named-content>,
+<named-content content-type="postcode">16146</named-content>,
+<named-content content-type="city">Genova</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF12"><label>12</label>
 <addr-line>
-<institution>INFN-Sezione di Genova</institution>, 
-<named-content content-type="street">Via Dodecaneso 33</named-content>, 
-<named-content content-type="postcode">16146</named-content> 
-<named-content content-type="city">Genova</named-content>, 
+<institution>INFN-Sezione di Genova</institution>,
+<named-content content-type="street">Via Dodecaneso 33</named-content>,
+<named-content content-type="postcode">16146</named-content>
+<named-content content-type="city">Genova</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF13"><label>13</label>
 <addr-line>
-<institution>Department of Physics “E. Pancini”, University Federico II</institution>, 
-<named-content content-type="street">Via Cinthia 6</named-content>, 
-<named-content content-type="postcode">80126</named-content> 
-<named-content content-type="city">Napoli</named-content>, 
+<institution>Department of Physics “E. Pancini”, University Federico II</institution>,
+<named-content content-type="street">Via Cinthia 6</named-content>,
+<named-content content-type="postcode">80126</named-content>
+<named-content content-type="city">Napoli</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF14"><label>14</label>
 <addr-line>
-<institution>INAF-Osservatorio Astronomico di Capodimonte</institution>, 
-<named-content content-type="street">Via Moiariello 16</named-content>, 
-<named-content content-type="postcode">80131</named-content> 
-<named-content content-type="city">Napoli</named-content>, 
+<institution>INAF-Osservatorio Astronomico di Capodimonte</institution>,
+<named-content content-type="street">Via Moiariello 16</named-content>,
+<named-content content-type="postcode">80131</named-content>
+<named-content content-type="city">Napoli</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF15"><label>15</label>
 <addr-line>
-<institution>INFN section of Naples</institution>, 
-<named-content content-type="street">Via Cinthia 6</named-content>, 
-<named-content content-type="postcode">80126</named-content> 
-<named-content content-type="city">Napoli</named-content>, 
+<institution>INFN section of Naples</institution>,
+<named-content content-type="street">Via Cinthia 6</named-content>,
+<named-content content-type="postcode">80126</named-content>
+<named-content content-type="city">Napoli</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF16"><label>16</label>
 <addr-line>
-<institution>Instituto de Astrofísica e Ciências do Espaço, Universidade do Porto, CAUP</institution>, 
-<named-content content-type="street">Rua das Estrelas</named-content>, 
-<named-content content-type="postcode">PT4150-762</named-content> 
-<named-content content-type="city">Porto</named-content>, 
+<institution>Instituto de Astrofísica e Ciências do Espaço, Universidade do Porto, CAUP</institution>,
+<named-content content-type="street">Rua das Estrelas</named-content>,
+<named-content content-type="postcode">PT4150-762</named-content>
+<named-content content-type="city">Porto</named-content>,
 <country>Portugal</country></addr-line></aff>
 <aff id="AFF17"><label>17</label>
 <addr-line>
-<institution>Dipartimento di Fisica, Università degli Studi di Torino</institution>, 
-<named-content content-type="street">Via P. Giuria 1</named-content>, 
-<named-content content-type="postcode">10125</named-content> 
-<named-content content-type="city">Torino</named-content>, 
+<institution>Dipartimento di Fisica, Università degli Studi di Torino</institution>,
+<named-content content-type="street">Via P. Giuria 1</named-content>,
+<named-content content-type="postcode">10125</named-content>
+<named-content content-type="city">Torino</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF18"><label>18</label>
 <addr-line>
-<institution>INFN-Sezione di Torino</institution>, 
-<named-content content-type="street">Via P. Giuria 1</named-content>, 
-<named-content content-type="postcode">10125</named-content> 
-<named-content content-type="city">Torino</named-content>, 
+<institution>INFN-Sezione di Torino</institution>,
+<named-content content-type="street">Via P. Giuria 1</named-content>,
+<named-content content-type="postcode">10125</named-content>
+<named-content content-type="city">Torino</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF19"><label>19</label>
 <addr-line>
-<institution>Institut de Física d’Altes Energies (IFAE), The Barcelona Institute of Science and Technology</institution>, 
-<named-content content-type="street">Campus UAB</named-content>, 
-<named-content content-type="postcode">08193</named-content> 
-<named-content content-type="city">Bellaterra (Barcelona)</named-content>, 
+<institution>Institut de Física d’Altes Energies (IFAE), The Barcelona Institute of Science and Technology</institution>,
+<named-content content-type="street">Campus UAB</named-content>,
+<named-content content-type="postcode">08193</named-content>
+<named-content content-type="city">Bellaterra (Barcelona)</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF20"><label>20</label>
 <addr-line>
-<institution>Port d’Informació Científica</institution>, 
-<named-content content-type="street">Campus UAB, C. Albareda s/n</named-content>, 
-<named-content content-type="postcode">08193</named-content> 
-<named-content content-type="city">Bellaterra (Barcelona)</named-content>, 
+<institution>Port d’Informació Científica</institution>,
+<named-content content-type="street">Campus UAB, C. Albareda s/n</named-content>,
+<named-content content-type="postcode">08193</named-content>
+<named-content content-type="city">Bellaterra (Barcelona)</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF21"><label>21</label>
 <addr-line>
-<institution>Institute for Theoretical Particle Physics and Cosmology (TTK), RWTH Aachen University</institution>, 
-<named-content content-type="postcode">52056</named-content> 
-<named-content content-type="city">Aachen</named-content>, 
+<institution>Institute for Theoretical Particle Physics and Cosmology (TTK), RWTH Aachen University</institution>,
+<named-content content-type="postcode">52056</named-content>
+<named-content content-type="city">Aachen</named-content>,
 <country>Germany</country></addr-line></aff>
 <aff id="AFF22"><label>22</label>
 <addr-line>
-<institution>INAF-Osservatorio Astronomico di Roma</institution>, 
-<named-content content-type="street">Via Frascati 33</named-content>, 
-<named-content content-type="postcode">00078</named-content> 
-<named-content content-type="city">Monteporzio Catone</named-content>, 
+<institution>INAF-Osservatorio Astronomico di Roma</institution>,
+<named-content content-type="street">Via Frascati 33</named-content>,
+<named-content content-type="postcode">00078</named-content>
+<named-content content-type="city">Monteporzio Catone</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF23"><label>23</label>
 <addr-line>
-<institution>Dipartimento di Fisica e Astronomia “Augusto Righi” - Alma Mater Studiorum Università di Bologna</institution>, 
-<named-content content-type="street">Viale Berti Pichat 6/2</named-content>, 
-<named-content content-type="postcode">40127</named-content> 
-<named-content content-type="city">Bologna</named-content>, 
+<institution>Dipartimento di Fisica e Astronomia “Augusto Righi” - Alma Mater Studiorum Università di Bologna</institution>,
+<named-content content-type="street">Viale Berti Pichat 6/2</named-content>,
+<named-content content-type="postcode">40127</named-content>
+<named-content content-type="city">Bologna</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF24"><label>24</label>
 <addr-line>
-<institution>Institute for Astronomy, University of Edinburgh</institution>, 
-<named-content content-type="street">Royal Observatory, Blackford Hill</named-content>, 
-<named-content content-type="city">Edinburgh</named-content> 
-<named-content content-type="postcode">EH9 3HJ</named-content>, 
+<institution>Institute for Astronomy, University of Edinburgh</institution>,
+<named-content content-type="street">Royal Observatory, Blackford Hill</named-content>,
+<named-content content-type="city">Edinburgh</named-content>
+<named-content content-type="postcode">EH9 3HJ</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF25"><label>25</label>
 <addr-line>
-<institution>Jodrell Bank Centre for Astrophysics, Department of Physics and Astronomy, University of Manchester</institution>, 
-<named-content content-type="street">Oxford Road</named-content>, 
-<named-content content-type="city">Manchester</named-content> 
-<named-content content-type="postcode">M13 9PL</named-content>, 
+<institution>Jodrell Bank Centre for Astrophysics, Department of Physics and Astronomy, University of Manchester</institution>,
+<named-content content-type="street">Oxford Road</named-content>,
+<named-content content-type="city">Manchester</named-content>
+<named-content content-type="postcode">M13 9PL</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF26"><label>26</label>
 <addr-line>
-<institution>European Space Agency/ESRIN</institution>, 
-<named-content content-type="street">Largo Galileo Galilei 1</named-content>, 
-<named-content content-type="postcode">00044</named-content> 
-<named-content content-type="city">Frascati, Roma</named-content>, 
+<institution>European Space Agency/ESRIN</institution>,
+<named-content content-type="street">Largo Galileo Galilei 1</named-content>,
+<named-content content-type="postcode">00044</named-content>
+<named-content content-type="city">Frascati, Roma</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF27"><label>27</label>
 <addr-line>
-<institution>ESAC/ESA, Camino Bajo del Castillo</institution>, 
-<named-content content-type="street">s/n., Urb. Villafranca del Castillo</named-content>, 
-<named-content content-type="postcode">28692</named-content> 
-<named-content content-type="street">Villanueva de la Cañada</named-content>, 
-<named-content content-type="city">Madrid</named-content>, 
+<institution>ESAC/ESA, Camino Bajo del Castillo</institution>,
+<named-content content-type="street">s/n., Urb. Villafranca del Castillo</named-content>,
+<named-content content-type="postcode">28692</named-content>
+<named-content content-type="street">Villanueva de la Cañada</named-content>,
+<named-content content-type="city">Madrid</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF28"><label>28</label>
 <addr-line>
-<institution>Université Claude Bernard Lyon 1</institution>, 
-<named-content content-type="street">CNRS/IN2P3, IP2I Lyon, UMR 5822</named-content>, 
-<named-content content-type="postcode">69100</named-content> 
-<named-content content-type="city">Villeurbanne</named-content>, 
+<institution>Université Claude Bernard Lyon 1</institution>,
+<named-content content-type="street">CNRS/IN2P3, IP2I Lyon, UMR 5822</named-content>,
+<named-content content-type="postcode">69100</named-content>
+<named-content content-type="city">Villeurbanne</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF29"><label>29</label>
 <addr-line>
-<institution>Institute of Physics, Laboratory of Astrophysics, Ecole Polytechnique Fédérale de Lausanne (EPFL)</institution>, 
-<named-content content-type="street">Observatoire de Sauverny</named-content>, 
-<named-content content-type="postcode">1290</named-content> 
-<named-content content-type="city">Versoix</named-content>, 
+<institution>Institute of Physics, Laboratory of Astrophysics, Ecole Polytechnique Fédérale de Lausanne (EPFL)</institution>,
+<named-content content-type="street">Observatoire de Sauverny</named-content>,
+<named-content content-type="postcode">1290</named-content>
+<named-content content-type="city">Versoix</named-content>,
 <country>Switzerland</country></addr-line></aff>
 <aff id="AFF30"><label>30</label>
 <addr-line>
-<institution>UCB Lyon 1</institution>, 
-<named-content content-type="street">CNRS/IN2P3, IUF, IP2I Lyon, 4 rue Enrico Fermi</named-content>, 
-<named-content content-type="postcode">69622</named-content> 
-<named-content content-type="city">Villeurbanne</named-content>, 
+<institution>UCB Lyon 1</institution>,
+<named-content content-type="street">CNRS/IN2P3, IUF, IP2I Lyon, 4 rue Enrico Fermi</named-content>,
+<named-content content-type="postcode">69622</named-content>
+<named-content content-type="city">Villeurbanne</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF31"><label>31</label>
 <addr-line>
-<institution>Departamento de Física, Faculdade de Ciências, Universidade de Lisboa</institution>, 
-<named-content content-type="street">Edifício C8, Campo Grande</named-content>, 
-<named-content content-type="postcode">PT1749-016</named-content> 
-<named-content content-type="city">Lisboa</named-content>, 
+<institution>Departamento de Física, Faculdade de Ciências, Universidade de Lisboa</institution>,
+<named-content content-type="street">Edifício C8, Campo Grande</named-content>,
+<named-content content-type="postcode">PT1749-016</named-content>
+<named-content content-type="city">Lisboa</named-content>,
 <country>Portugal</country></addr-line></aff>
 <aff id="AFF32"><label>32</label>
 <addr-line>
-<institution>Instituto de Astrofísica e Ciências do Espaço, Faculdade de Ciên- cias, Universidade de Lisboa</institution>, 
-<named-content content-type="street">Campo Grande</named-content>, 
-<named-content content-type="postcode">1749-016</named-content> 
-<named-content content-type="city">Lisboa</named-content>, 
+<institution>Instituto de Astrofísica e Ciências do Espaço, Faculdade de Ciên- cias, Universidade de Lisboa</institution>,
+<named-content content-type="street">Campo Grande</named-content>,
+<named-content content-type="postcode">1749-016</named-content>
+<named-content content-type="city">Lisboa</named-content>,
 <country>Portugal</country></addr-line></aff>
 <aff id="AFF33"><label>33</label>
 <addr-line>
-<institution>Department of Astronomy, University of Geneva</institution>, 
-<named-content content-type="street">ch. d’Ecogia 16</named-content>, 
-<named-content content-type="postcode">1290</named-content> 
-<named-content content-type="city">Versoix</named-content>, 
+<institution>Department of Astronomy, University of Geneva</institution>,
+<named-content content-type="street">ch. d’Ecogia 16</named-content>,
+<named-content content-type="postcode">1290</named-content>
+<named-content content-type="city">Versoix</named-content>,
 <country>Switzerland</country></addr-line></aff>
 <aff id="AFF34"><label>34</label>
 <addr-line>
-<institution>INAF-Istituto di Astrofisica e Planetologia Spaziali</institution>, 
-<named-content content-type="street">via del Fosso del Cavaliere, 100</named-content>, 
-<named-content content-type="postcode">00100</named-content> 
-<named-content content-type="city">Roma</named-content>, 
+<institution>INAF-Istituto di Astrofisica e Planetologia Spaziali</institution>,
+<named-content content-type="street">via del Fosso del Cavaliere, 100</named-content>,
+<named-content content-type="postcode">00100</named-content>
+<named-content content-type="city">Roma</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF35"><label>35</label>
 <addr-line>
-<institution>Université Paris-Saclay, CNRS, Institut d’astrophysique spatiale</institution>, 
-<named-content content-type="postcode">91405</named-content> 
-<named-content content-type="city">Orsay</named-content>, 
+<institution>Université Paris-Saclay, CNRS, Institut d’astrophysique spatiale</institution>,
+<named-content content-type="postcode">91405</named-content>
+<named-content content-type="city">Orsay</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF36"><label>36</label>
 <addr-line>
-<institution>INFN-Padova</institution>, 
-<named-content content-type="street">Via Marzolo 8</named-content>, 
-<named-content content-type="postcode">35131</named-content> 
-<named-content content-type="city">Padova</named-content>, 
+<institution>INFN-Padova</institution>,
+<named-content content-type="street">Via Marzolo 8</named-content>,
+<named-content content-type="postcode">35131</named-content>
+<named-content content-type="city">Padova</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF37"><label>37</label>
 <addr-line>
-<institution>INAF-Osservatorio Astronomico di Trieste</institution>, 
-<named-content content-type="street">Via G. B. Tiepolo 11</named-content>, 
-<named-content content-type="postcode">34143</named-content> 
-<named-content content-type="city">Trieste</named-content>, 
+<institution>INAF-Osservatorio Astronomico di Trieste</institution>,
+<named-content content-type="street">Via G. B. Tiepolo 11</named-content>,
+<named-content content-type="postcode">34143</named-content>
+<named-content content-type="city">Trieste</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF38"><label>38</label>
 <addr-line>
-<institution>Aix-Marseille Université, CNRS/IN2P3, CPPM</institution>, 
-<named-content content-type="city">Marseille</named-content>, 
+<institution>Aix-Marseille Université, CNRS/IN2P3, CPPM</institution>,
+<named-content content-type="city">Marseille</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF39"><label>39</label>
 <addr-line>
-<institution>Istituto Nazionale di Fisica Nucleare</institution>, 
-<named-content content-type="street">Sezione di Bologna, Via Irnerio 46</named-content>, 
-<named-content content-type="postcode">40126</named-content> 
-<named-content content-type="city">Bologna</named-content>, 
+<institution>Istituto Nazionale di Fisica Nucleare</institution>,
+<named-content content-type="street">Sezione di Bologna, Via Irnerio 46</named-content>,
+<named-content content-type="postcode">40126</named-content>
+<named-content content-type="city">Bologna</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF40"><label>40</label>
 <addr-line>
-<institution>INAF-Osservatorio Astronomico di Padova</institution>, 
-<named-content content-type="street">Via dell’Osservatorio 5</named-content>, 
-<named-content content-type="postcode">35122</named-content> 
-<named-content content-type="city">Padova</named-content>, 
+<institution>INAF-Osservatorio Astronomico di Padova</institution>,
+<named-content content-type="street">Via dell’Osservatorio 5</named-content>,
+<named-content content-type="postcode">35122</named-content>
+<named-content content-type="city">Padova</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF41"><label>41</label>
 <addr-line>
-<institution>Universitäts-Sternwarte München, Fakultät für Physik, Ludwig-Maximilians-Universität München</institution>, 
-<named-content content-type="street">Scheinerstrasse 1</named-content>, 
-<named-content content-type="postcode">81679</named-content> 
-<named-content content-type="city">München</named-content>, 
+<institution>Universitäts-Sternwarte München, Fakultät für Physik, Ludwig-Maximilians-Universität München</institution>,
+<named-content content-type="street">Scheinerstrasse 1</named-content>,
+<named-content content-type="postcode">81679</named-content>
+<named-content content-type="city">München</named-content>,
 <country>Germany</country></addr-line></aff>
 <aff id="AFF42"><label>42</label>
 <addr-line>
-<institution>Institute of Theoretical Astrophysics, University of Oslo</institution>, 
-<named-content content-type="postbox">PO Box 1029</named-content> 
-<named-content content-type="street">Blindern</named-content>, 
-<named-content content-type="postcode">0315</named-content> 
-<named-content content-type="city">Oslo</named-content>, 
+<institution>Institute of Theoretical Astrophysics, University of Oslo</institution>,
+<named-content content-type="postbox">PO Box 1029</named-content>
+<named-content content-type="street">Blindern</named-content>,
+<named-content content-type="postcode">0315</named-content>
+<named-content content-type="city">Oslo</named-content>,
 <country>Norway</country></addr-line></aff>
 <aff id="AFF43"><label>43</label>
 <addr-line>
-<institution>Jet Propulsion Laboratory, California Institute of Technology</institution>, 
-<named-content content-type="street">4800 Oak Grove Drive</named-content>, 
-<named-content content-type="city">Pasadena</named-content>, 
-<named-content content-type="state">CA</named-content>, 
-<named-content content-type="postcode">91109</named-content>, 
+<institution>Jet Propulsion Laboratory, California Institute of Technology</institution>,
+<named-content content-type="street">4800 Oak Grove Drive</named-content>,
+<named-content content-type="city">Pasadena</named-content>,
+<named-content content-type="state">CA</named-content>,
+<named-content content-type="postcode">91109</named-content>,
 <country>USA</country></addr-line></aff>
 <aff id="AFF44"><label>44</label>
 <addr-line>
-<institution>Department of Physics, Lancaster University</institution>, 
-<named-content content-type="city">Lancaster</named-content>, 
-<named-content content-type="postcode">LA1 4YB</named-content>, 
+<institution>Department of Physics, Lancaster University</institution>,
+<named-content content-type="city">Lancaster</named-content>,
+<named-content content-type="postcode">LA1 4YB</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF45"><label>45</label>
 <addr-line>
-<institution>Felix Hormuth Engineering</institution>, 
-<named-content content-type="street">Goethestr. 17</named-content>, 
-<named-content content-type="postcode">69181</named-content> 
-<named-content content-type="city">Leimen</named-content>, 
+<institution>Felix Hormuth Engineering</institution>,
+<named-content content-type="street">Goethestr. 17</named-content>,
+<named-content content-type="postcode">69181</named-content>
+<named-content content-type="city">Leimen</named-content>,
 <country>Germany</country></addr-line></aff>
 <aff id="AFF46"><label>46</label>
 <addr-line>
-<institution>Technical University of Denmark</institution>, 
-<named-content content-type="street">Elektrovej 327, 2800 Kgs.</named-content> 
-<named-content content-type="city">Lyngby</named-content>, 
+<institution>Technical University of Denmark</institution>,
+<named-content content-type="street">Elektrovej 327, 2800 Kgs.</named-content>
+<named-content content-type="city">Lyngby</named-content>,
 <country>Denmark</country></addr-line></aff>
 <aff id="AFF47"><label>47</label>
 <addr-line>
-<institution>Cosmic Dawn Center (DAWN)</institution>, 
+<institution>Cosmic Dawn Center (DAWN)</institution>,
 <country>Denmark</country></addr-line></aff>
 <aff id="AFF48"><label>48</label>
 <addr-line>
-<institution>Institut d’Astrophysique de Paris</institution>, 
-<named-content content-type="street">UMR 7095, CNRS, and Sorbonne Université, 98 bis boulevard Arago</named-content>, 
-<named-content content-type="postcode">75014</named-content> 
-<named-content content-type="city">Paris</named-content>, 
+<institution>Institut d’Astrophysique de Paris</institution>,
+<named-content content-type="street">UMR 7095, CNRS, and Sorbonne Université, 98 bis boulevard Arago</named-content>,
+<named-content content-type="postcode">75014</named-content>
+<named-content content-type="city">Paris</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF49"><label>49</label>
 <addr-line>
-<institution>Max-Planck-Institut für Astronomie</institution>, 
-<named-content content-type="street">Königstuhl 17</named-content>, 
-<named-content content-type="postcode">69117</named-content> 
-<named-content content-type="city">Heidelberg</named-content>, 
+<institution>Max-Planck-Institut für Astronomie</institution>,
+<named-content content-type="street">Königstuhl 17</named-content>,
+<named-content content-type="postcode">69117</named-content>
+<named-content content-type="city">Heidelberg</named-content>,
 <country>Germany</country></addr-line></aff>
 <aff id="AFF50"><label>50</label>
 <addr-line>
-<institution>Department of Physics and Helsinki Institute of Physics</institution>, 
-<named-content content-type="street">Gustaf Hällströmin katu 2, 00014 University of Helsinki</named-content>, 
+<institution>Department of Physics and Helsinki Institute of Physics</institution>,
+<named-content content-type="street">Gustaf Hällströmin katu 2, 00014 University of Helsinki</named-content>,
 <country>Finland</country></addr-line></aff>
 <aff id="AFF51"><label>51</label>
 <addr-line>
-<institution>AIM, CEA, CNRS, Université Paris-Saclay, Université de Paris</institution>, 
-<named-content content-type="postcode">91191</named-content> 
-<named-content content-type="city">Gif-sur-Yvette</named-content>, 
+<institution>AIM, CEA, CNRS, Université Paris-Saclay, Université de Paris</institution>,
+<named-content content-type="postcode">91191</named-content>
+<named-content content-type="city">Gif-sur-Yvette</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF52"><label>52</label>
 <addr-line>
-<institution>Université de Genève, Département de Physique Théorique and Centre for Astroparticle Physics</institution>, 
-<named-content content-type="street">24 quai Ernest-Ansermet</named-content>, 
-<named-content content-type="postcode">1211</named-content> 
-<named-content content-type="city">Genève 4</named-content>, 
+<institution>Université de Genève, Département de Physique Théorique and Centre for Astroparticle Physics</institution>,
+<named-content content-type="street">24 quai Ernest-Ansermet</named-content>,
+<named-content content-type="postcode">1211</named-content>
+<named-content content-type="city">Genève 4</named-content>,
 <country>Switzerland</country></addr-line></aff>
 <aff id="AFF53"><label>53</label>
 <addr-line>
-<institution>Department of Physics</institution>, 
-<named-content content-type="postbox">P.O. Box 64</named-content>, 
-<named-content content-type="postcode">00014</named-content> 
-<named-content content-type="street">University of Helsinki</named-content>, 
+<institution>Department of Physics</institution>,
+<named-content content-type="postbox">P.O. Box 64</named-content>,
+<named-content content-type="postcode">00014</named-content>
+<named-content content-type="street">University of Helsinki</named-content>,
 <country>Finland</country></addr-line></aff>
 <aff id="AFF54"><label>54</label>
 <addr-line>
-<institution>Helsinki Institute of Physics</institution>, 
-<named-content content-type="street">Gustaf Hällströmin katu 2, University of Helsinki</named-content>, 
-<named-content content-type="city">Helsinki</named-content>, 
+<institution>Helsinki Institute of Physics</institution>,
+<named-content content-type="street">Gustaf Hällströmin katu 2, University of Helsinki</named-content>,
+<named-content content-type="city">Helsinki</named-content>,
 <country>Finland</country></addr-line></aff>
 <aff id="AFF55"><label>55</label>
 <addr-line>
-<institution>NOVA optical infrared instrumentation group at ASTRON</institution>, 
-<named-content content-type="street">Oude Hoogeveensedijk 4</named-content>, 
-<named-content content-type="postcode">7991PD</named-content> 
-<named-content content-type="city">Dwingeloo</named-content>, 
+<institution>NOVA optical infrared instrumentation group at ASTRON</institution>,
+<named-content content-type="street">Oude Hoogeveensedijk 4</named-content>,
+<named-content content-type="postcode">7991PD</named-content>
+<named-content content-type="city">Dwingeloo</named-content>,
 <country>The Netherlands</country></addr-line></aff>
 <aff id="AFF56"><label>56</label>
 <addr-line>
-<institution>Dipartimento di Fisica “Aldo Pontremoli”, Università degli Studi di Milano</institution>, 
-<named-content content-type="street">Via Celoria 16</named-content>, 
-<named-content content-type="postcode">20133</named-content> 
-<named-content content-type="city">Milano</named-content>, 
+<institution>Dipartimento di Fisica “Aldo Pontremoli”, Università degli Studi di Milano</institution>,
+<named-content content-type="street">Via Celoria 16</named-content>,
+<named-content content-type="postcode">20133</named-content>
+<named-content content-type="city">Milano</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF57"><label>57</label>
 <addr-line>
-<institution>INAF-IASF Milano</institution>, 
-<named-content content-type="street">Via Alfonso Corti 12</named-content>, 
-<named-content content-type="postcode">20133</named-content> 
-<named-content content-type="city">Milano</named-content>, 
+<institution>INAF-IASF Milano</institution>,
+<named-content content-type="street">Via Alfonso Corti 12</named-content>,
+<named-content content-type="postcode">20133</named-content>
+<named-content content-type="city">Milano</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF58"><label>58</label>
 <addr-line>
-<institution>INFN-Sezione di Milano</institution>, 
-<named-content content-type="street">Via Celoria 16</named-content>, 
-<named-content content-type="postcode">20133</named-content> 
-<named-content content-type="city">Milano</named-content>, 
+<institution>INFN-Sezione di Milano</institution>,
+<named-content content-type="street">Via Celoria 16</named-content>,
+<named-content content-type="postcode">20133</named-content>
+<named-content content-type="city">Milano</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF59"><label>59</label>
 <addr-line>
-<institution>Universität Bonn, Argelander-Institut für Astronomie</institution>, 
-<named-content content-type="street">Auf dem Hügel 71</named-content>, 
-<named-content content-type="postcode">53121</named-content> 
-<named-content content-type="city">Bonn</named-content>, 
+<institution>Universität Bonn, Argelander-Institut für Astronomie</institution>,
+<named-content content-type="street">Auf dem Hügel 71</named-content>,
+<named-content content-type="postcode">53121</named-content>
+<named-content content-type="city">Bonn</named-content>,
 <country>Germany</country></addr-line></aff>
 <aff id="AFF60"><label>60</label>
 <addr-line>
-<institution>Aix-Marseille Université, CNRS, CNES, LAM</institution>, 
-<named-content content-type="city">Marseille</named-content>, 
+<institution>Aix-Marseille Université, CNRS, CNES, LAM</institution>,
+<named-content content-type="city">Marseille</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF61"><label>61</label>
 <addr-line>
-<institution>Dipartimento di Fisica e Astronomia “Augusto Righi” - Alma Mater Studiorum Università di Bologna</institution>, 
-<named-content content-type="street">via Piero Gobetti 93/2</named-content>, 
-<named-content content-type="postcode">40129</named-content> 
-<named-content content-type="city">Bologna</named-content>, 
+<institution>Dipartimento di Fisica e Astronomia “Augusto Righi” - Alma Mater Studiorum Università di Bologna</institution>,
+<named-content content-type="street">via Piero Gobetti 93/2</named-content>,
+<named-content content-type="postcode">40129</named-content>
+<named-content content-type="city">Bologna</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF62"><label>62</label>
 <addr-line>
-<institution>Department of Physics, Centre for Extragalactic Astronomy, Durham University</institution>, 
-<named-content content-type="street">South Road</named-content>, 
-<named-content content-type="postcode">DH1 3LE</named-content>, 
+<institution>Department of Physics, Centre for Extragalactic Astronomy, Durham University</institution>,
+<named-content content-type="street">South Road</named-content>,
+<named-content content-type="postcode">DH1 3LE</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF63"><label>63</label>
 <addr-line>
-<institution>Université Côte d’Azur, Observatoire de la Côte d’Azur, CNRS, Laboratoire Lagrange</institution>, 
-<named-content content-type="street">Bd de l’Observatoire, CS 34229</named-content>, 
-<named-content content-type="postcode">06304</named-content> 
-<named-content content-type="city">Nice cedex 4</named-content>, 
+<institution>Université Côte d’Azur, Observatoire de la Côte d’Azur, CNRS, Laboratoire Lagrange</institution>,
+<named-content content-type="street">Bd de l’Observatoire, CS 34229</named-content>,
+<named-content content-type="postcode">06304</named-content>
+<named-content content-type="city">Nice cedex 4</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF64"><label>64</label>
 <addr-line>
-<institution>Université Paris Cité, CNRS</institution>, 
-<named-content content-type="street">Astroparticule et Cosmologie</named-content>, 
-<named-content content-type="postcode">75013</named-content> 
-<named-content content-type="city">Paris</named-content>, 
+<institution>Université Paris Cité, CNRS</institution>,
+<named-content content-type="street">Astroparticule et Cosmologie</named-content>,
+<named-content content-type="postcode">75013</named-content>
+<named-content content-type="city">Paris</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF65"><label>65</label>
 <addr-line>
-<institution>Institut d’Astrophysique de Paris</institution>, 
-<named-content content-type="street">98bis Boulevard Arago</named-content>, 
-<named-content content-type="postcode">75014</named-content> 
-<named-content content-type="city">Paris</named-content>, 
+<institution>Institut d’Astrophysique de Paris</institution>,
+<named-content content-type="street">98bis Boulevard Arago</named-content>,
+<named-content content-type="postcode">75014</named-content>
+<named-content content-type="city">Paris</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF66"><label>66</label>
 <addr-line>
-<institution>European Space Agency/ESTEC</institution>, 
-<named-content content-type="street">Keplerlaan 1</named-content>, 
-<named-content content-type="postcode">2201 AZ</named-content> 
-<named-content content-type="city">Noordwijk</named-content>, 
+<institution>European Space Agency/ESTEC</institution>,
+<named-content content-type="street">Keplerlaan 1</named-content>,
+<named-content content-type="postcode">2201 AZ</named-content>
+<named-content content-type="city">Noordwijk</named-content>,
 <country>The Netherlands</country></addr-line></aff>
 <aff id="AFF67"><label>67</label>
 <addr-line>
-<institution>School of Mathematics, Statistics and Physics, Newcastle University</institution>, 
-<named-content content-type="street">Herschel Building</named-content>, 
-<named-content content-type="city">Newcastle-upon-Tyne</named-content>, 
-<named-content content-type="postcode">NE1 7RU</named-content>, 
+<institution>School of Mathematics, Statistics and Physics, Newcastle University</institution>,
+<named-content content-type="street">Herschel Building</named-content>,
+<named-content content-type="city">Newcastle-upon-Tyne</named-content>,
+<named-content content-type="postcode">NE1 7RU</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF68"><label>68</label>
 <addr-line>
-<institution>Department of Physics, Institute for Computational Cosmology, Durham University</institution>, 
-<named-content content-type="street">South Road</named-content>, 
-<named-content content-type="postcode">DH1 3LE</named-content>, 
+<institution>Department of Physics, Institute for Computational Cosmology, Durham University</institution>,
+<named-content content-type="street">South Road</named-content>,
+<named-content content-type="postcode">DH1 3LE</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF69"><label>69</label>
 <addr-line>
-<institution>Department of Physics and Astronomy, University of Aarhus</institution>, 
-<named-content content-type="street">Ny Munkegade 120</named-content>, 
-<named-content content-type="postcode">8000</named-content> 
-<named-content content-type="city">Aarhus C</named-content>, 
+<institution>Department of Physics and Astronomy, University of Aarhus</institution>,
+<named-content content-type="street">Ny Munkegade 120</named-content>,
+<named-content content-type="postcode">8000</named-content>
+<named-content content-type="city">Aarhus C</named-content>,
 <country>Denmark</country></addr-line></aff>
 <aff id="AFF70"><label>70</label>
 <addr-line>
-<institution>Waterloo Centre for Astrophysics, University of Waterloo</institution>, 
-<named-content content-type="city">Waterloo</named-content>, 
-<named-content content-type="state">Ontario</named-content> 
-<named-content content-type="postcode">N2L 3G1</named-content>, 
+<institution>Waterloo Centre for Astrophysics, University of Waterloo</institution>,
+<named-content content-type="city">Waterloo</named-content>,
+<named-content content-type="state">Ontario</named-content>
+<named-content content-type="postcode">N2L 3G1</named-content>,
 <country>Canada</country></addr-line></aff>
 <aff id="AFF71"><label>71</label>
 <addr-line>
-<institution>Department of Physics and Astronomy, University of Waterloo</institution>, 
-<named-content content-type="city">Waterloo</named-content>, 
-<named-content content-type="state">Ontario</named-content> 
-<named-content content-type="postcode">N2L 3G1</named-content>, 
+<institution>Department of Physics and Astronomy, University of Waterloo</institution>,
+<named-content content-type="city">Waterloo</named-content>,
+<named-content content-type="state">Ontario</named-content>
+<named-content content-type="postcode">N2L 3G1</named-content>,
 <country>Canada</country></addr-line></aff>
 <aff id="AFF72"><label>72</label>
 <addr-line>
-<institution>Perimeter Institute for Theoretical Physics</institution>, 
-<named-content content-type="city">Waterloo</named-content>, 
-<named-content content-type="state">Ontario</named-content> 
-<named-content content-type="postcode">N2L 2Y5</named-content>, 
+<institution>Perimeter Institute for Theoretical Physics</institution>,
+<named-content content-type="city">Waterloo</named-content>,
+<named-content content-type="state">Ontario</named-content>
+<named-content content-type="postcode">N2L 2Y5</named-content>,
 <country>Canada</country></addr-line></aff>
 <aff id="AFF73"><label>73</label>
 <addr-line>
-<institution>Space Science Data Center, Italian Space Agency</institution>, 
-<named-content content-type="street">via del Politecnico snc</named-content>, 
-<named-content content-type="postcode">00133</named-content> 
-<named-content content-type="city">Roma</named-content>, 
+<institution>Space Science Data Center, Italian Space Agency</institution>,
+<named-content content-type="street">via del Politecnico snc</named-content>,
+<named-content content-type="postcode">00133</named-content>
+<named-content content-type="city">Roma</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF74"><label>74</label>
 <addr-line>
-<institution>Centre National d’Etudes Spatiales – Centre spatial de Toulouse</institution>, 
-<named-content content-type="street">18 avenue Edouard Belin</named-content>, 
-<named-content content-type="postcode">31401</named-content> 
-<named-content content-type="city">Toulouse Cedex 9</named-content>, 
+<institution>Centre National d’Etudes Spatiales – Centre spatial de Toulouse</institution>,
+<named-content content-type="street">18 avenue Edouard Belin</named-content>,
+<named-content content-type="postcode">31401</named-content>
+<named-content content-type="city">Toulouse Cedex 9</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF75"><label>75</label>
 <addr-line>
-<institution>Institute of Space Science</institution>, 
-<named-content content-type="street">Str. Atomistilor, nr. 409 Măgurele</named-content>, 
-<named-content content-type="city">Ilfov</named-content>, 
-<named-content content-type="postcode">077125</named-content>, 
+<institution>Institute of Space Science</institution>,
+<named-content content-type="street">Str. Atomistilor, nr. 409 Măgurele</named-content>,
+<named-content content-type="city">Ilfov</named-content>,
+<named-content content-type="postcode">077125</named-content>,
 <country>Romania</country></addr-line></aff>
 <aff id="AFF76"><label>76</label>
 <addr-line>
-<institution>Instituto de Astrofísica de Canarias</institution>, 
-<named-content content-type="street">Calle Vía Láctea s/n</named-content>, 
-<named-content content-type="postcode">38204</named-content>, 
-<named-content content-type="city">San Cristóbal de La Laguna</named-content>, 
-<named-content content-type="state">Tenerife</named-content>, 
+<institution>Instituto de Astrofísica de Canarias</institution>,
+<named-content content-type="street">Calle Vía Láctea s/n</named-content>,
+<named-content content-type="postcode">38204</named-content>,
+<named-content content-type="city">San Cristóbal de La Laguna</named-content>,
+<named-content content-type="state">Tenerife</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF77"><label>77</label>
 <addr-line>
-<institution>Departamento de Astrofísica, Universidad de La Laguna</institution>, 
-<named-content content-type="postcode">38206</named-content>, 
-<named-content content-type="city">La Laguna</named-content>, 
-<named-content content-type="state">Tenerife</named-content>, 
+<institution>Departamento de Astrofísica, Universidad de La Laguna</institution>,
+<named-content content-type="postcode">38206</named-content>,
+<named-content content-type="city">La Laguna</named-content>,
+<named-content content-type="state">Tenerife</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF78"><label>78</label>
 <addr-line>
-<institution>Dipartimento di Fisica e Astronomia “G. Galilei”, Università di Padova</institution>, 
-<named-content content-type="street">Via Marzolo 8</named-content>, 
-<named-content content-type="postcode">35131</named-content> 
-<named-content content-type="city">Padova</named-content>, 
+<institution>Dipartimento di Fisica e Astronomia “G. Galilei”, Università di Padova</institution>,
+<named-content content-type="street">Via Marzolo 8</named-content>,
+<named-content content-type="postcode">35131</named-content>
+<named-content content-type="city">Padova</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF79"><label>79</label>
 <addr-line>
-<institution>Departamento de Física, FCFM, Universidad de Chile</institution>, 
-<named-content content-type="street">Blanco Encalada 2008</named-content>, 
-<named-content content-type="city">Santiago</named-content>, 
+<institution>Departamento de Física, FCFM, Universidad de Chile</institution>,
+<named-content content-type="street">Blanco Encalada 2008</named-content>,
+<named-content content-type="city">Santiago</named-content>,
 <country>Chile</country></addr-line></aff>
 <aff id="AFF80"><label>80</label>
 <addr-line>
-<institution>Institut d’Estudis Espacials de Catalunya (IEEC), Edifici RDIT</institution>, 
-<named-content content-type="street">Campus UPC</named-content>, 
-<named-content content-type="postcode">08860</named-content> 
-<named-content content-type="city">Castelldefels, Barcelona</named-content>, 
+<institution>Institut d’Estudis Espacials de Catalunya (IEEC), Edifici RDIT</institution>,
+<named-content content-type="street">Campus UPC</named-content>,
+<named-content content-type="postcode">08860</named-content>
+<named-content content-type="city">Castelldefels, Barcelona</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF81"><label>81</label>
 <addr-line>
-<institution>Institute of Space Sciences (ICE, CSIC)</institution>, 
-<named-content content-type="street">Campus UAB, Carrer de Can Magrans, s/n</named-content>, 
-<named-content content-type="postcode">08193</named-content> 
-<named-content content-type="city">Barcelona</named-content>, 
+<institution>Institute of Space Sciences (ICE, CSIC)</institution>,
+<named-content content-type="street">Campus UAB, Carrer de Can Magrans, s/n</named-content>,
+<named-content content-type="postcode">08193</named-content>
+<named-content content-type="city">Barcelona</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF82"><label>82</label>
 <addr-line>
-<institution>Satlantis, University Science Park</institution>, 
-<named-content content-type="street">Sede Bld 48940</named-content>, 
-<named-content content-type="city">Leioa-Bilbao</named-content>, 
+<institution>Satlantis, University Science Park</institution>,
+<named-content content-type="street">Sede Bld 48940</named-content>,
+<named-content content-type="city">Leioa-Bilbao</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF83"><label>83</label>
 <addr-line>
-<institution>Centro de Investigaciones Energéticas, Medioambientales y Tec- nológicas (CIEMAT)</institution>, 
-<named-content content-type="street">Avenida Complutense 40</named-content>, 
-<named-content content-type="postcode">28040</named-content> 
-<named-content content-type="city">Madrid</named-content>, 
+<institution>Centro de Investigaciones Energéticas, Medioambientales y Tec- nológicas (CIEMAT)</institution>,
+<named-content content-type="street">Avenida Complutense 40</named-content>,
+<named-content content-type="postcode">28040</named-content>
+<named-content content-type="city">Madrid</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF84"><label>84</label>
 <addr-line>
-<institution>Instituto de Astrofísica e Ciências do Espaço, Faculdade de Ciên- cias, Universidade de Lisboa</institution>, 
-<named-content content-type="street">Tapada da Ajuda</named-content>, 
-<named-content content-type="postcode">1349-018</named-content> 
-<named-content content-type="city">Lisboa</named-content>, 
+<institution>Instituto de Astrofísica e Ciências do Espaço, Faculdade de Ciên- cias, Universidade de Lisboa</institution>,
+<named-content content-type="street">Tapada da Ajuda</named-content>,
+<named-content content-type="postcode">1349-018</named-content>
+<named-content content-type="city">Lisboa</named-content>,
 <country>Portugal</country></addr-line></aff>
 <aff id="AFF85"><label>85</label>
 <addr-line>
-<institution>Universidad Politécnica de Cartagena, Departamento de Electrónica y Tecnología de Computadoras</institution>, 
-<named-content content-type="street">Plaza del Hospital 1</named-content>, 
-<named-content content-type="postcode">30202</named-content> 
-<named-content content-type="city">Cartagena</named-content>, 
+<institution>Universidad Politécnica de Cartagena, Departamento de Electrónica y Tecnología de Computadoras</institution>,
+<named-content content-type="street">Plaza del Hospital 1</named-content>,
+<named-content content-type="postcode">30202</named-content>
+<named-content content-type="city">Cartagena</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF86"><label>86</label>
 <addr-line>
-<institution>Kapteyn Astronomical Institute, University of Groningen</institution>, 
-<named-content content-type="postbox">PO Box 800</named-content>, 
-<named-content content-type="postcode">9700 AV</named-content> 
-<named-content content-type="city">Groningen</named-content>, 
+<institution>Kapteyn Astronomical Institute, University of Groningen</institution>,
+<named-content content-type="postbox">PO Box 800</named-content>,
+<named-content content-type="postcode">9700 AV</named-content>
+<named-content content-type="city">Groningen</named-content>,
 <country>The Netherlands</country></addr-line></aff>
 <aff id="AFF87"><label>87</label>
 <addr-line>
-<institution>INFN-Bologna</institution>, 
-<named-content content-type="street">Via Irnerio 46</named-content>, 
-<named-content content-type="postcode">40126</named-content> 
-<named-content content-type="city">Bologna</named-content>, 
+<institution>INFN-Bologna</institution>,
+<named-content content-type="street">Via Irnerio 46</named-content>,
+<named-content content-type="postcode">40126</named-content>
+<named-content content-type="city">Bologna</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF88"><label>88</label>
 <addr-line>
-<institution>Infrared Processing and Analysis Center, California Institute of Technology</institution>, 
-<named-content content-type="city">Pasadena</named-content>, 
-<named-content content-type="state">CA</named-content> 
-<named-content content-type="postcode">91125</named-content>, 
+<institution>Infrared Processing and Analysis Center, California Institute of Technology</institution>,
+<named-content content-type="city">Pasadena</named-content>,
+<named-content content-type="state">CA</named-content>
+<named-content content-type="postcode">91125</named-content>,
 <country>USA</country></addr-line></aff>
 <aff id="AFF89"><label>89</label>
 <addr-line>
-<institution>IFPU, Institute for Fundamental Physics of the Universe</institution>, 
-<named-content content-type="street">via Beirut 2</named-content>, 
-<named-content content-type="postcode">34151</named-content> 
-<named-content content-type="city">Trieste</named-content>, 
+<institution>IFPU, Institute for Fundamental Physics of the Universe</institution>,
+<named-content content-type="street">via Beirut 2</named-content>,
+<named-content content-type="postcode">34151</named-content>
+<named-content content-type="city">Trieste</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF90"><label>90</label>
 <addr-line>
-<institution>INAF, Istituto di Radioastronomia</institution>, 
-<named-content content-type="street">Via Piero Gobetti 101</named-content>, 
-<named-content content-type="postcode">40129</named-content> 
-<named-content content-type="city">Bologna</named-content>, 
+<institution>INAF, Istituto di Radioastronomia</institution>,
+<named-content content-type="street">Via Piero Gobetti 101</named-content>,
+<named-content content-type="postcode">40129</named-content>
+<named-content content-type="city">Bologna</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF91"><label>91</label>
 <addr-line>
-<institution>Centre de Calcul de l’IN2P3/CNRS</institution>, 
-<named-content content-type="street">21 avenue Pierre de Coubertin</named-content> 
-<named-content content-type="postcode">69627</named-content> 
-<named-content content-type="city">Villeurbanne Cedex</named-content>, 
+<institution>Centre de Calcul de l’IN2P3/CNRS</institution>,
+<named-content content-type="street">21 avenue Pierre de Coubertin</named-content>
+<named-content content-type="postcode">69627</named-content>
+<named-content content-type="city">Villeurbanne Cedex</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF92"><label>92</label>
 <addr-line>
-<institution>INFN-Sezione di Roma, Piazzale Aldo Moro</institution>, 
-<named-content content-type="street">2 - c/o Dipartimento di Fisica, Edificio G. Marconi</named-content>, 
-<named-content content-type="postcode">00185</named-content> 
-<named-content content-type="city">Roma</named-content>, 
+<institution>INFN-Sezione di Roma, Piazzale Aldo Moro</institution>,
+<named-content content-type="street">2 - c/o Dipartimento di Fisica, Edificio G. Marconi</named-content>,
+<named-content content-type="postcode">00185</named-content>
+<named-content content-type="city">Roma</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF93"><label>93</label>
 <addr-line>
-<institution>Institut für Theoretische Physik, University of Heidelberg</institution>, 
-<named-content content-type="street">Philosophenweg 16</named-content>, 
-<named-content content-type="postcode">69120</named-content> 
-<named-content content-type="city">Heidelberg</named-content>, 
+<institution>Institut für Theoretische Physik, University of Heidelberg</institution>,
+<named-content content-type="street">Philosophenweg 16</named-content>,
+<named-content content-type="postcode">69120</named-content>
+<named-content content-type="city">Heidelberg</named-content>,
 <country>Germany</country></addr-line></aff>
 <aff id="AFF94"><label>94</label>
 <addr-line>
-<institution>Université St Joseph; Faculty of Sciences</institution>, 
-<named-content content-type="city">Beirut</named-content>, 
+<institution>Université St Joseph; Faculty of Sciences</institution>,
+<named-content content-type="city">Beirut</named-content>,
 <country>Lebanon</country></addr-line></aff>
 <aff id="AFF95"><label>95</label>
 <addr-line>
-<institution>Junia, EPA department</institution>, 
-<named-content content-type="street">41 Bd Vauban</named-content>, 
-<named-content content-type="postcode">59800</named-content> 
-<named-content content-type="city">Lille</named-content>, 
+<institution>Junia, EPA department</institution>,
+<named-content content-type="street">41 Bd Vauban</named-content>,
+<named-content content-type="postcode">59800</named-content>
+<named-content content-type="city">Lille</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF96"><label>96</label>
 <addr-line>
-<institution>SISSA, International School for Advanced Studies</institution>, 
-<named-content content-type="street">Via Bonomea 265</named-content>, 
-<named-content content-type="postcode">34136</named-content> 
-<named-content content-type="city">Trieste TS</named-content>, 
+<institution>SISSA, International School for Advanced Studies</institution>,
+<named-content content-type="street">Via Bonomea 265</named-content>,
+<named-content content-type="postcode">34136</named-content>
+<named-content content-type="city">Trieste TS</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF97"><label>97</label>
 <addr-line>
-<institution>INFN, Sezione di Trieste</institution>, 
-<named-content content-type="street">Via Valerio 2</named-content>, 
-<named-content content-type="postcode">34127</named-content> 
-<named-content content-type="city">Trieste TS</named-content>, 
+<institution>INFN, Sezione di Trieste</institution>,
+<named-content content-type="street">Via Valerio 2</named-content>,
+<named-content content-type="postcode">34127</named-content>
+<named-content content-type="city">Trieste TS</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF98"><label>98</label>
 <addr-line>
-<institution>ICSC - Centro Nazionale di Ricerca in High Performance Computing</institution>, 
-<named-content content-type="street">Big Data e Quantum Computing, Via Magnanelli 2</named-content>, 
-<named-content content-type="city">Bologna</named-content>, 
+<institution>ICSC - Centro Nazionale di Ricerca in High Performance Computing</institution>,
+<named-content content-type="street">Big Data e Quantum Computing, Via Magnanelli 2</named-content>,
+<named-content content-type="city">Bologna</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF99"><label>99</label>
 <addr-line>
-<institution>Instituto de Física Teórica UAM-CSIC</institution>, 
-<named-content content-type="street">Campus de Cantoblanco</named-content>, 
-<named-content content-type="postcode">28049</named-content> 
-<named-content content-type="city">Madrid</named-content>, 
+<institution>Instituto de Física Teórica UAM-CSIC</institution>,
+<named-content content-type="street">Campus de Cantoblanco</named-content>,
+<named-content content-type="postcode">28049</named-content>
+<named-content content-type="city">Madrid</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF100"><label>100</label>
 <addr-line>
-<institution>CERCA/ISO, Department of Physics, Case Western Reserve University</institution>, 
-<named-content content-type="street">10900 Euclid Avenue</named-content>, 
-<named-content content-type="city">Cleveland</named-content>, 
-<named-content content-type="state">OH</named-content> 
-<named-content content-type="postcode">44106</named-content>, 
+<institution>CERCA/ISO, Department of Physics, Case Western Reserve University</institution>,
+<named-content content-type="street">10900 Euclid Avenue</named-content>,
+<named-content content-type="city">Cleveland</named-content>,
+<named-content content-type="state">OH</named-content>
+<named-content content-type="postcode">44106</named-content>,
 <country>USA</country></addr-line></aff>
 <aff id="AFF101"><label>101</label>
 <addr-line>
-<institution>Laboratoire Univers et Théorie, Observatoire de Paris, Université PSL, Université Paris Cité, CNRS</institution>, 
-<named-content content-type="postcode">92190</named-content> 
-<named-content content-type="city">Meudon</named-content>, 
+<institution>Laboratoire Univers et Théorie, Observatoire de Paris, Université PSL, Université Paris Cité, CNRS</institution>,
+<named-content content-type="postcode">92190</named-content>
+<named-content content-type="city">Meudon</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF102"><label>102</label>
 <addr-line>
-<institution>Dipartimento di Fisica e Scienze della Terra, Università degli Studi di Ferrara</institution>, 
-<named-content content-type="street">Via Giuseppe Saragat 1</named-content>, 
-<named-content content-type="postcode">44122</named-content> 
-<named-content content-type="city">Ferrara</named-content>, 
+<institution>Dipartimento di Fisica e Scienze della Terra, Università degli Studi di Ferrara</institution>,
+<named-content content-type="street">Via Giuseppe Saragat 1</named-content>,
+<named-content content-type="postcode">44122</named-content>
+<named-content content-type="city">Ferrara</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF103"><label>103</label>
 <addr-line>
-<institution>Istituto Nazionale di Fisica Nucleare, Sezione di Ferrara</institution>, 
-<named-content content-type="street">Via Giuseppe Saragat 1</named-content>, 
-<named-content content-type="postcode">44122</named-content> 
-<named-content content-type="city">Ferrara</named-content>, 
+<institution>Istituto Nazionale di Fisica Nucleare, Sezione di Ferrara</institution>,
+<named-content content-type="street">Via Giuseppe Saragat 1</named-content>,
+<named-content content-type="postcode">44122</named-content>
+<named-content content-type="city">Ferrara</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF104"><label>104</label>
 <addr-line>
-<institution>Kavli Institute for the Physics and Mathematics of the Universe (WPI), University of Tokyo</institution>, 
-<named-content content-type="city">Kashiwa, Chiba</named-content> 
-<named-content content-type="postcode">277-8583</named-content>, 
+<institution>Kavli Institute for the Physics and Mathematics of the Universe (WPI), University of Tokyo</institution>,
+<named-content content-type="city">Kashiwa, Chiba</named-content>
+<named-content content-type="postcode">277-8583</named-content>,
 <country>Japan</country></addr-line></aff>
 <aff id="AFF105"><label>105</label>
 <addr-line>
-<institution>Dipartimento di Fisica - Sezione di Astronomia, Università di Trieste</institution>, 
-<named-content content-type="street">Via Tiepolo 11</named-content>, 
-<named-content content-type="postcode">34131</named-content> 
-<named-content content-type="city">Trieste</named-content>, 
+<institution>Dipartimento di Fisica - Sezione di Astronomia, Università di Trieste</institution>,
+<named-content content-type="street">Via Tiepolo 11</named-content>,
+<named-content content-type="postcode">34131</named-content>
+<named-content content-type="city">Trieste</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF106"><label>106</label>
 <addr-line>
-<institution>Minnesota Institute for Astrophysics, University of Minnesota</institution>, 
-<named-content content-type="street">116 Church St SE</named-content>, 
-<named-content content-type="city">Minneapolis</named-content>, 
-<named-content content-type="state">MN</named-content> 
-<named-content content-type="postcode">55455</named-content>, 
+<institution>Minnesota Institute for Astrophysics, University of Minnesota</institution>,
+<named-content content-type="street">116 Church St SE</named-content>,
+<named-content content-type="city">Minneapolis</named-content>,
+<named-content content-type="state">MN</named-content>
+<named-content content-type="postcode">55455</named-content>,
 <country>USA</country></addr-line></aff>
 <aff id="AFF107"><label>107</label>
 <addr-line>
-<institution>Institute Lorentz, Leiden University</institution>, 
-<named-content content-type="street">Niels Bohrweg 2</named-content>, 
-<named-content content-type="postcode">2333 CA</named-content> 
-<named-content content-type="city">Leiden</named-content>, 
+<institution>Institute Lorentz, Leiden University</institution>,
+<named-content content-type="street">Niels Bohrweg 2</named-content>,
+<named-content content-type="postcode">2333 CA</named-content>
+<named-content content-type="city">Leiden</named-content>,
 <country>The Netherlands</country></addr-line></aff>
 <aff id="AFF108"><label>108</label>
 <addr-line>
-<institution>Institute for Astronomy, University of Hawaii</institution>, 
-<named-content content-type="street">2680 Woodlawn Drive</named-content>, 
-<named-content content-type="city">Honolulu</named-content>, 
-<named-content content-type="state">HI</named-content> 
-<named-content content-type="postcode">96822</named-content>, 
+<institution>Institute for Astronomy, University of Hawaii</institution>,
+<named-content content-type="street">2680 Woodlawn Drive</named-content>,
+<named-content content-type="city">Honolulu</named-content>,
+<named-content content-type="state">HI</named-content>
+<named-content content-type="postcode">96822</named-content>,
 <country>USA</country></addr-line></aff>
 <aff id="AFF109"><label>109</label>
 <addr-line>
-<institution>Department of Physics &amp; Astronomy, University of California Irvine</institution>, 
-<named-content content-type="city">Irvine</named-content> 
-<named-content content-type="state">CA</named-content> 
-<named-content content-type="postcode">92697</named-content>, 
+<institution>Department of Physics &amp; Astronomy, University of California Irvine</institution>,
+<named-content content-type="city">Irvine</named-content>
+<named-content content-type="state">CA</named-content>
+<named-content content-type="postcode">92697</named-content>,
 <country>USA</country></addr-line></aff>
 <aff id="AFF110"><label>110</label>
 <addr-line>
-<institution>Department of Astronomy &amp; Physics and Institute for Computational Astrophysics, Saint Mary’s University</institution>, 
-<named-content content-type="street">923 Robie Street, Halifax</named-content>, 
-<named-content content-type="city">Nova Scotia</named-content>, 
-<named-content content-type="postcode">B3H 3C3</named-content>, 
+<institution>Department of Astronomy &amp; Physics and Institute for Computational Astrophysics, Saint Mary’s University</institution>,
+<named-content content-type="street">923 Robie Street, Halifax</named-content>,
+<named-content content-type="city">Nova Scotia</named-content>,
+<named-content content-type="postcode">B3H 3C3</named-content>,
 <country>Canada</country></addr-line></aff>
 <aff id="AFF111"><label>111</label>
 <addr-line>
-<institution>Departamento Física Aplicada, Universidad Politécnica de Cartagena</institution>, 
-<named-content content-type="street">Campus Muralla del Mar</named-content>, 
-<named-content content-type="postcode">30202</named-content> 
-<named-content content-type="city">Cartagena</named-content>, 
-<named-content content-type="state">Murcia</named-content>, 
+<institution>Departamento Física Aplicada, Universidad Politécnica de Cartagena</institution>,
+<named-content content-type="street">Campus Muralla del Mar</named-content>,
+<named-content content-type="postcode">30202</named-content>
+<named-content content-type="city">Cartagena</named-content>,
+<named-content content-type="state">Murcia</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF112"><label>112</label>
 <addr-line>
-<institution>Department of Physics, Oxford University</institution>, 
-<named-content content-type="street">Keble Road</named-content>, 
-<named-content content-type="city">Oxford</named-content> 
-<named-content content-type="postcode">OX1 3RH</named-content>, 
+<institution>Department of Physics, Oxford University</institution>,
+<named-content content-type="street">Keble Road</named-content>,
+<named-content content-type="city">Oxford</named-content>
+<named-content content-type="postcode">OX1 3RH</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF113"><label>113</label>
 <addr-line>
-<institution>Institute of Cosmology and Gravitation, University of Portsmouth</institution>, 
-<named-content content-type="city">Portsmouth</named-content> 
-<named-content content-type="postcode">PO1 3FX</named-content>, 
+<institution>Institute of Cosmology and Gravitation, University of Portsmouth</institution>,
+<named-content content-type="city">Portsmouth</named-content>
+<named-content content-type="postcode">PO1 3FX</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF114"><label>114</label>
 <addr-line>
-<institution>Department of Computer Science, Aalto University</institution>, 
-<named-content content-type="postbox">PO Box 15400</named-content>, 
-<named-content content-type="city">Espoo</named-content> 
-<named-content content-type="postcode">00 076</named-content>, 
+<institution>Department of Computer Science, Aalto University</institution>,
+<named-content content-type="postbox">PO Box 15400</named-content>,
+<named-content content-type="city">Espoo</named-content>
+<named-content content-type="postcode">00 076</named-content>,
 <country>Finland</country></addr-line></aff>
 <aff id="AFF115"><label>115</label>
 <addr-line>
-<institution>Ruhr University Bochum, Faculty of Physics and Astronomy, Astronomical Institute (AIRUB), German Centre for Cosmological Lensing (GCCL)</institution>, 
-<named-content content-type="postcode">44780</named-content> 
-<named-content content-type="city">Bochum</named-content>, 
+<institution>Ruhr University Bochum, Faculty of Physics and Astronomy, Astronomical Institute (AIRUB), German Centre for Cosmological Lensing (GCCL)</institution>,
+<named-content content-type="postcode">44780</named-content>
+<named-content content-type="city">Bochum</named-content>,
 <country>Germany</country></addr-line></aff>
 <aff id="AFF116"><label>116</label>
 <addr-line>
-<institution>Univ. Grenoble Alpes, CNRS, Grenoble INP, LPSC-IN2P3</institution>, 
-<named-content content-type="street">53 Avenue des Martyrs</named-content>, 
-<named-content content-type="postcode">38000</named-content> 
-<named-content content-type="city">Grenoble</named-content>, 
+<institution>Univ. Grenoble Alpes, CNRS, Grenoble INP, LPSC-IN2P3</institution>,
+<named-content content-type="street">53 Avenue des Martyrs</named-content>,
+<named-content content-type="postcode">38000</named-content>
+<named-content content-type="city">Grenoble</named-content>,
 <country>France</country></addr-line></aff>
 <aff id="AFF117"><label>117</label>
 <addr-line>
-<institution>Department of Physics and Astronomy</institution>, 
-<named-content content-type="street">Vesilinnantie 5, 20014 University of Turku</named-content>, 
+<institution>Department of Physics and Astronomy</institution>,
+<named-content content-type="street">Vesilinnantie 5, 20014 University of Turku</named-content>,
 <country>Finland</country></addr-line></aff>
 <aff id="AFF118"><label>118</label>
 <addr-line>
-<institution>Serco for European Space Agency (ESA)</institution>, 
-<named-content content-type="street">Camino bajo del Castillo, s/n, Urbanizacion Villafranca del Castillo, Villanueva de la Cañada</named-content>, 
-<named-content content-type="postcode">28692</named-content> 
-<named-content content-type="city">Madrid</named-content>, 
+<institution>Serco for European Space Agency (ESA)</institution>,
+<named-content content-type="street">Camino bajo del Castillo, s/n, Urbanizacion Villafranca del Castillo, Villanueva de la Cañada</named-content>,
+<named-content content-type="postcode">28692</named-content>
+<named-content content-type="city">Madrid</named-content>,
 <country>Spain</country></addr-line></aff>
 <aff id="AFF119"><label>119</label>
 <addr-line>
-<institution>ARC Centre of Excellence for Dark Matter Particle Physics</institution>, 
-<named-content content-type="city">Melbourne</named-content>, 
+<institution>ARC Centre of Excellence for Dark Matter Particle Physics</institution>,
+<named-content content-type="city">Melbourne</named-content>,
 <country>Australia</country></addr-line></aff>
 <aff id="AFF120"><label>120</label>
 <addr-line>
-<institution>Centre for Astrophysics &amp; Supercomputing, Swinburne University of Technology</institution>, 
-<named-content content-type="city">Victoria</named-content> 
-<named-content content-type="postcode">3122</named-content>, 
+<institution>Centre for Astrophysics &amp; Supercomputing, Swinburne University of Technology</institution>,
+<named-content content-type="city">Victoria</named-content>
+<named-content content-type="postcode">3122</named-content>,
 <country>Australia</country></addr-line></aff>
 <aff id="AFF121"><label>121</label>
 <addr-line>
-<institution>School of Physics and Astronomy, Queen Mary University of London</institution>, 
-<named-content content-type="street">Mile End Road</named-content>, 
-<named-content content-type="city">London</named-content> 
-<named-content content-type="postcode">E1 4NS</named-content>, 
+<institution>School of Physics and Astronomy, Queen Mary University of London</institution>,
+<named-content content-type="street">Mile End Road</named-content>,
+<named-content content-type="city">London</named-content>
+<named-content content-type="postcode">E1 4NS</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF122"><label>122</label>
 <addr-line>
-<institution>Department of Physics and Astronomy, University of the Western Cape</institution>, 
-<named-content content-type="street">Bellville</named-content>, 
-<named-content content-type="city">Cape Town</named-content> 
-<named-content content-type="postcode">7535</named-content>, 
+<institution>Department of Physics and Astronomy, University of the Western Cape</institution>,
+<named-content content-type="street">Bellville</named-content>,
+<named-content content-type="city">Cape Town</named-content>
+<named-content content-type="postcode">7535</named-content>,
 <country>South Africa</country></addr-line></aff>
 <aff id="AFF123"><label>123</label>
 <addr-line>
-<institution>ICTP South American Institute for Fundamental Research, Instituto de Física Teórica, Universidade Estadual Paulista</institution>, 
-<named-content content-type="city">São Paulo</named-content>, 
+<institution>ICTP South American Institute for Fundamental Research, Instituto de Física Teórica, Universidade Estadual Paulista</institution>,
+<named-content content-type="city">São Paulo</named-content>,
 <country>Brazil</country></addr-line></aff>
 <aff id="AFF124"><label>124</label>
 <addr-line>
-<institution>Oskar Klein Centre for Cosmoparticle Physics, Department of Physics, Stockholm University</institution>, 
-<named-content content-type="city">Stockholm</named-content> 
-<named-content content-type="postcode">106 91</named-content>, 
+<institution>Oskar Klein Centre for Cosmoparticle Physics, Department of Physics, Stockholm University</institution>,
+<named-content content-type="city">Stockholm</named-content>
+<named-content content-type="postcode">106 91</named-content>,
 <country>Sweden</country></addr-line></aff>
 <aff id="AFF125"><label>125</label>
 <addr-line>
-<institution>Astrophysics Group, Blackett Laboratory, Imperial College London</institution>, 
-<named-content content-type="city">London</named-content> 
-<named-content content-type="postcode">SW7 2AZ</named-content>, 
+<institution>Astrophysics Group, Blackett Laboratory, Imperial College London</institution>,
+<named-content content-type="city">London</named-content>
+<named-content content-type="postcode">SW7 2AZ</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF126"><label>126</label>
 <addr-line>
-<institution>INAF-Osservatorio Astrofisico di Arcetri</institution>, 
-<named-content content-type="street">Largo E. Fermi 5</named-content>, 
-<named-content content-type="postcode">50125</named-content> 
-<named-content content-type="city">Firenze</named-content>, 
+<institution>INAF-Osservatorio Astrofisico di Arcetri</institution>,
+<named-content content-type="street">Largo E. Fermi 5</named-content>,
+<named-content content-type="postcode">50125</named-content>
+<named-content content-type="city">Firenze</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF127"><label>127</label>
 <addr-line>
-<institution>Dipartimento di Fisica, Sapienza Università di Roma</institution>, 
-<named-content content-type="street">Piazzale Aldo Moro 2</named-content>, 
-<named-content content-type="postcode">00185</named-content> 
-<named-content content-type="city">Roma</named-content>, 
+<institution>Dipartimento di Fisica, Sapienza Università di Roma</institution>,
+<named-content content-type="street">Piazzale Aldo Moro 2</named-content>,
+<named-content content-type="postcode">00185</named-content>
+<named-content content-type="city">Roma</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF128"><label>128</label>
 <addr-line>
-<institution>Centro de Astrofísica da Universidade do Porto</institution>, 
-<named-content content-type="street">Rua das Estrelas</named-content>, 
-<named-content content-type="postcode">4150-762</named-content> 
-<named-content content-type="city">Porto</named-content>, 
+<institution>Centro de Astrofísica da Universidade do Porto</institution>,
+<named-content content-type="street">Rua das Estrelas</named-content>,
+<named-content content-type="postcode">4150-762</named-content>
+<named-content content-type="city">Porto</named-content>,
 <country>Portugal</country></addr-line></aff>
 <aff id="AFF129"><label>129</label>
 <addr-line>
-<institution>Dipartimento di Fisica, Università di Roma Tor Vergata</institution>, 
-<named-content content-type="street">Via della Ricerca Scientifica 1</named-content>, 
-<named-content content-type="city">Roma</named-content>, 
+<institution>Dipartimento di Fisica, Università di Roma Tor Vergata</institution>,
+<named-content content-type="street">Via della Ricerca Scientifica 1</named-content>,
+<named-content content-type="city">Roma</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF130"><label>130</label>
 <addr-line>
-<institution>INFN</institution>, 
-<named-content content-type="street">Sezione di Roma 2, Via della Ricerca Scientifica 1</named-content>, 
-<named-content content-type="city">Roma</named-content>, 
+<institution>INFN</institution>,
+<named-content content-type="street">Sezione di Roma 2, Via della Ricerca Scientifica 1</named-content>,
+<named-content content-type="city">Roma</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF131"><label>131</label>
 <addr-line>
-<institution>Institute of Astronomy, University of Cambridge</institution>, 
-<named-content content-type="street">Madingley Road</named-content>, 
-<named-content content-type="city">Cambridge</named-content> 
-<named-content content-type="postcode">CB3 0HA</named-content>, 
+<institution>Institute of Astronomy, University of Cambridge</institution>,
+<named-content content-type="street">Madingley Road</named-content>,
+<named-content content-type="city">Cambridge</named-content>
+<named-content content-type="postcode">CB3 0HA</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF132"><label>132</label>
 <addr-line>
-<institution>Department of Astrophysics, University of Zurich</institution>, 
-<named-content content-type="street">Winterthur-erstrasse 190</named-content>, 
-<named-content content-type="postcode">8057</named-content> 
-<named-content content-type="city">Zurich</named-content>, 
+<institution>Department of Astrophysics, University of Zurich</institution>,
+<named-content content-type="street">Winterthur-erstrasse 190</named-content>,
+<named-content content-type="postcode">8057</named-content>
+<named-content content-type="city">Zurich</named-content>,
 <country>Switzerland</country></addr-line></aff>
 <aff id="AFF133"><label>133</label>
 <addr-line>
-<institution>Dipartimento di Fisica, Università degli studi di Genova, and INFN-Sezione di Genova</institution>, 
-<named-content content-type="street">via Dodecaneso 33</named-content>, 
-<named-content content-type="postcode">16146</named-content> 
-<named-content content-type="city">Genova</named-content>, 
+<institution>Dipartimento di Fisica, Università degli studi di Genova, and INFN-Sezione di Genova</institution>,
+<named-content content-type="street">via Dodecaneso 33</named-content>,
+<named-content content-type="postcode">16146</named-content>
+<named-content content-type="city">Genova</named-content>,
 <country>Italy</country></addr-line></aff>
 <aff id="AFF134"><label>134</label>
 <addr-line>
-<institution>Theoretical astrophysics, Department of Physics and Astronomy, Uppsala University</institution>, 
-<named-content content-type="postbox">Box 515</named-content>, 
-<named-content content-type="postcode">751 20</named-content> 
-<named-content content-type="city">Uppsala</named-content>, 
+<institution>Theoretical astrophysics, Department of Physics and Astronomy, Uppsala University</institution>,
+<named-content content-type="postbox">Box 515</named-content>,
+<named-content content-type="postcode">751 20</named-content>
+<named-content content-type="city">Uppsala</named-content>,
 <country>Sweden</country></addr-line></aff>
 <aff id="AFF135"><label>135</label>
 <addr-line>
-<institution>Department of Physics and Astronomy, University College London</institution>, 
-<named-content content-type="street">Gower Street</named-content>, 
-<named-content content-type="city">London</named-content> 
-<named-content content-type="postcode">WC1E 6BT</named-content>, 
+<institution>Department of Physics and Astronomy, University College London</institution>,
+<named-content content-type="street">Gower Street</named-content>,
+<named-content content-type="city">London</named-content>
+<named-content content-type="postcode">WC1E 6BT</named-content>,
 <country>UK</country></addr-line></aff>
 <aff id="AFF136"><label>136</label>
 <addr-line>
-<institution>Department of Astrophysical Sciences, Peyton Hall, Princeton University</institution>, 
-<named-content content-type="city">Princeton</named-content>, 
-<named-content content-type="state">NJ</named-content> 
-<named-content content-type="postcode">08544</named-content>, 
+<institution>Department of Astrophysical Sciences, Peyton Hall, Princeton University</institution>,
+<named-content content-type="city">Princeton</named-content>,
+<named-content content-type="state">NJ</named-content>
+<named-content content-type="postcode">08544</named-content>,
 <country>USA</country></addr-line></aff>
 <aff id="AFF137"><label>137</label>
 <addr-line>
-<institution>Niels Bohr Institute, University of Copenhagen</institution>, 
-<named-content content-type="street">Jagtvej 128</named-content>, 
-<named-content content-type="postcode">2200</named-content> 
-<named-content content-type="city">Copenhagen</named-content>, 
+<institution>Niels Bohr Institute, University of Copenhagen</institution>,
+<named-content content-type="street">Jagtvej 128</named-content>,
+<named-content content-type="postcode">2200</named-content>
+<named-content content-type="city">Copenhagen</named-content>,
 <country>Denmark</country></addr-line></aff>
 <aff id="AFF138"><label>138</label>
 <addr-line>
-<institution>Center for Cosmology and Particle Physics, Department of Physics, New York University</institution>, 
-<named-content content-type="city">New York</named-content>, 
-<named-content content-type="state">NY</named-content> 
-<named-content content-type="postcode">10003</named-content>, 
+<institution>Center for Cosmology and Particle Physics, Department of Physics, New York University</institution>,
+<named-content content-type="city">New York</named-content>,
+<named-content content-type="state">NY</named-content>
+<named-content content-type="postcode">10003</named-content>,
 <country>USA</country></addr-line></aff>
 <aff id="AFF139"><label>139</label>
 <addr-line>
-<institution>Center for Computational Astrophysics, Flatiron Institute</institution>, 
-<named-content content-type="street">162 5th Avenue</named-content>, 
-<named-content content-type="postcode">10010</named-content>, 
-<named-content content-type="city">New York</named-content>, 
-<named-content content-type="state">NY</named-content>, 
+<institution>Center for Computational Astrophysics, Flatiron Institute</institution>,
+<named-content content-type="street">162 5th Avenue</named-content>,
+<named-content content-type="postcode">10010</named-content>,
+<named-content content-type="city">New York</named-content>,
+<named-content content-type="state">NY</named-content>,
 <country>USA</country></addr-line></aff>
 <author-notes>
 <fn id="FN1"><label>★</label><p>Corresponding author; <email>alain.blanchard@irap.omp.eu</email></p></fn>

--- a/tests/stubdata/output/jats_edp_null_nested_collab_aa50368-24.json
+++ b/tests/stubdata/output/jats_edp_null_nested_collab_aa50368-24.json
@@ -1,0 +1,3133 @@
+{
+  "abstract": {
+    "textEnglish": "Future data provided by the Euclid mission will allow us to better understand the cosmic history of the Universe. A metric of its performance is the figure-of-merit (FoM) of dark energy, usually estimated with Fisher forecasts. The expected FoM has previously been estimated taking into account the two main probes of Euclid, namely the three-dimensional clustering of the spectroscopic galaxy sample, and the so-called 3\u00d72pt signal from the photometric sample (i.e., the weak lensing signal, the galaxy clustering, and their cross-correlation). So far, these two probes have been treated as independent. In this paper, we introduce a new observable given by the ratio of the (angular) two-point correlation function of galaxies from the two surveys. For identical (normalised) selection functions, this observable is unaffected by sampling noise, and its variance is solely controlled by Poisson noise. We present forecasts for Euclid where this multi-tracer method is applied and is particularly relevant because the two surveys will cover the same area of the sky. This method allows for the exploitation of the combination of the spectroscopic and photometric samples. When the correlation between this new observable and the other probes is not taken into account, a significant gain is obtained in the FoM, as well as in the constraints on other cosmological parameters. The benefit is more pronounced for a commonly investigated modified gravity model, namely the \u03b3 parametrisation of the growth factor. However, the correlation between the different probes is found to be significant and hence the actual gain is uncertain. We present various strategies for circumventing this issue and still extract useful information from the new observable."
+  },
+  "authors": [
+    {
+      "attrib": {
+        "collab": true
+      },
+      "name": {
+        "collab": "Euclid Collaboration\n\n\nDournacF.\n1\n\n\nhttp://orcid.org/0000-0001-8555-9003\nBlanchardA.\n1\n\u2605\n\n\nhttp://orcid.org/0000-0003-4285-9086\nIli\u0107S.\n2\n1\n\n\nhttp://orcid.org/0000-0002-9416-2320\nLamineB.\n1\n\n\nhttp://orcid.org/0000-0002-3199-0399\nTutusausI.\n1\n\n\nAmaraA.\n3\n\n\nhttp://orcid.org/0000-0002-2041-8784\nAndreonS.\n4\n\n\nhttp://orcid.org/0000-0003-4444-8651\nAuricchioN.\n5\n\n\nhttp://orcid.org/0000-0002-1371-5705\nAusselH.\n6\n\n\nhttp://orcid.org/0000-0003-4145-1943\nBaldiM.\n7\n5\n8\n\n\nhttp://orcid.org/0000-0002-8900-0298\nBardelliS.\n5\n\n\nBodendorfC.\n9\n\n\nhttp://orcid.org/0000-0002-3336-9977\nBoninoD.\n10\n\n\nhttp://orcid.org/0000-0002-0808-6908\nBranchiniE.\n11\n12\n4\n\n\nBrau-NogueS.\n1\n\n\nhttp://orcid.org/0000-0001-9506-5680\nBresciaM.\n13\n14\n15\n\n\nhttp://orcid.org/0000-0003-4359-8797\nBrinchmannJ.\n16\n\n\nhttp://orcid.org/0000-0003-3399-3574\nCameraS.\n17\n18\n10\n\n\nhttp://orcid.org/0000-0002-3309-7692\nCapobiancoV.\n10\n\n\nhttp://orcid.org/0000-0002-3130-0204\nCarreteroJ.\n19\n20\n\n\nhttp://orcid.org/0000-0002-4751-5138\nCasasS.\n21\n\n\nhttp://orcid.org/0000-0001-9875-8263\nCastellanoM.\n22\n\n\nhttp://orcid.org/0000-0002-3787-4196\nCavuotiS.\n14\n15\n\n\nCimattiA.\n23\n\n\nhttp://orcid.org/0000-0003-2508-0046\nCongedoG.\n24\n\n\nConseliceC. J.\n25\n\n\nhttp://orcid.org/0000-0002-6710-8476\nConversiL.\n26\n27\n\n\nhttp://orcid.org/0000-0002-5317-7518\nCopinY.\n28\n\n\nhttp://orcid.org/0000-0003-0758-6510\nCourbinF.\n29\n\n\nhttp://orcid.org/0000-0003-0509-1776\nCourtoisH. M.\n30\n\n\nDa SilvaA.\n31\n32\n\n\nhttp://orcid.org/0000-0002-5887-6799\nDegaudenziH.\n33\n\n\nhttp://orcid.org/0000-0002-4767-2360\nDi GiorgioA. M.\n34\n\n\nhttp://orcid.org/0000-0001-5075-1601\nDinisJ.\n31\n32\n\n\nhttp://orcid.org/0000-0003-4203-3954\nDouspisM.\n35\n\n\nhttp://orcid.org/0000-0002-6533-2810\nDubathF.\n33\n\n\nDupacX.\n27\n\n\nhttp://orcid.org/0000-0002-1128-0664\nDusiniS.\n36\n\n\nEaletA.\n28\n\n\nhttp://orcid.org/0000-0002-3089-7846\nFarinaM.\n34\n\n\nhttp://orcid.org/0000-0002-9594-9387\nFarrensS.\n6\n\n\nFerriolS.\n28\n\n\nhttp://orcid.org/0000-0002-7400-2135\nFrailisM.\n37\n\n\nhttp://orcid.org/0000-0002-0585-6591\nFranceschiE.\n5\n\n\nhttp://orcid.org/0000-0002-3748-5115\nGaleottaS.\n37\n\n\nhttp://orcid.org/0000-0003-4744-9748\nGillardW.\n38\n\n\nhttp://orcid.org/0000-0002-4478-1270\nGillisB.\n24\n\n\nhttp://orcid.org/0000-0002-9590-7961\nGiocoliC.\n5\n39\n\n\nhttp://orcid.org/0000-0003-2694-9284\nGranettB. R.\n4\n\n\nhttp://orcid.org/0000-0002-5688-0663\nGrazianA.\n40\n\n\nGruppF.\n9\n41\n\n\nhttp://orcid.org/0000-0001-9648-7260\nHauganS. V. H.\n42\n\n\nHolmesW.\n43\n\n\nhttp://orcid.org/0000-0002-2960-978X\nHookI.\n44\n\n\nhttp://orcid.org/0009-0000-2474-3130\nHormuthF.\n45\n\n\nhttp://orcid.org/0000-0002-3363-0936\nHornstrupA.\n46\n47\n\n\nHudelotP.\n48\n\n\nhttp://orcid.org/0000-0003-3804-2137\nJahnkeK.\n49\n\n\nhttp://orcid.org/0000-0003-1804-7715\nKeih\u00e4nenE.\n50\n\n\nhttp://orcid.org/0000-0002-0302-5735\nKermicheS.\n38\n\n\nhttp://orcid.org/0000-0002-2590-1273\nKiesslingA.\n43\n\n\nhttp://orcid.org/0000-0001-9513-7138\nKilbingerM.\n51\n\n\nhttp://orcid.org/0009-0006-5823-4880\nKubikB.\n28\n\n\nhttp://orcid.org/0000-0003-2791-2117\nK\u00fcmmelM.\n41\n\n\nhttp://orcid.org/0000-0002-3052-7394\nKunzM.\n52\n\n\nhttp://orcid.org/0000-0002-4618-3063\nKurki-SuonioH.\n53\n54\n\n\nhttp://orcid.org/0000-0003-4172-4606\nLigoriS.\n10\n\n\nhttp://orcid.org/0000-0003-4324-7794\nLiljeP. B.\n42\n\n\nhttp://orcid.org/0000-0003-2317-5471\nLindholmV.\n53\n54\n\n\nhttp://orcid.org/0000-0001-5966-1434\nLloroI.\n55\n\n\nhttp://orcid.org/0000-0002-4761-1242\nMainoD.\n56\n57\n58\n\n\nhttp://orcid.org/0000-0003-2593-4355\nMaioranoE.\n5\n\n\nhttp://orcid.org/0000-0001-5758-4658\nMansuttiO.\n37\n\n\nhttp://orcid.org/0000-0001-7242-3852\nMarggrafO.\n59\n\n\nhttp://orcid.org/0000-0001-6764-073X\nMarkovicK.\n43\n\n\nhttp://orcid.org/0000-0003-2786-7790\nMartinetN.\n60\n\n\nhttp://orcid.org/0000-0002-8850-0303\nMarulliF.\n61\n5\n8\n\n\nhttp://orcid.org/0000-0002-6085-3780\nMasseyR.\n62\n\n\nMaurogordatoS.\n63\n\n\nhttp://orcid.org/0000-0002-4040-7783\nMedinaceliE.\n5\n\n\nhttp://orcid.org/0000-0002-2849-559X\nMeiS.\n64\n\n\nMellierY.\n65\n48\n\n\nhttp://orcid.org/0000-0003-1225-7084\nMeneghettiM.\n5\n8\n\n\nhttp://orcid.org/0000-0001-6870-8900\nMerlinE.\n22\n\n\nMeylanG.\n29\n\n\nhttp://orcid.org/0000-0002-7616-7136\nMorescoM.\n61\n5\n\n\nhttp://orcid.org/0000-0002-3473-6716\nMoscardiniL.\n61\n5\n8\n\n\nhttp://orcid.org/0000-0002-1751-5946\nMunariE.\n37\n\n\nNiemiS.-M.\n66\n\n\nhttp://orcid.org/0000-0002-8987-7401\nNightingaleJ. W.\n67\n68\n\n\nhttp://orcid.org/0000-0001-7951-0166\nPadillaC.\n19\n\n\nhttp://orcid.org/0000-0002-8108-9179\nPaltaniS.\n33\n\n\nhttp://orcid.org/0000-0002-4869-3227\nPasianF.\n37\n\n\nPedersenK.\n69\n\n\nhttp://orcid.org/0000-0002-0644-5727\nPercivalW. J.\n70\n71\n72\n\n\nhttp://orcid.org/0000-0002-4203-9320\nPettorinoV.\n66\n\n\nhttp://orcid.org/0000-0002-0249-2104\nPiresS.\n6\n\n\nhttp://orcid.org/0000-0003-4067-9196\nPolentaG.\n73\n\n\nPoncetM.\n74\n\n\nhttp://orcid.org/0000-0001-9045-9154\nPopaL. A.\n75\n\n\nhttp://orcid.org/0000-0001-7085-0412\nPozzettiL.\n5\n\n\nhttp://orcid.org/0000-0002-7819-6918\nRaisonF.\n9\n\n\nReboloR.\n76\n77\n\n\nhttp://orcid.org/0000-0001-9856-1970\nRenziA.\n78\n36\n\n\nhttp://orcid.org/0000-0002-4485-8549\nRhodesJ.\n43\n\n\nhttp://orcid.org/0000-0001-7020-1172\nRiccioG.\n14\n\n\nhttp://orcid.org/0000-0003-3069-9222\nRomelliE.\n37\n\n\nhttp://orcid.org/0000-0001-9587-7822\nRoncarelliM.\n5\n\n\nRossettiE.\n7\n\n\nhttp://orcid.org/0000-0003-0378-7032\nSagliaR.\n41\n9\n\n\nhttp://orcid.org/0000-0001-7089-4503\nSaponeD.\n79\n\n\nSchneiderP.\n59\n\n\nhttp://orcid.org/0000-0003-0505-3710\nSecrounA.\n38\n\n\nhttp://orcid.org/0000-0003-2907-353X\nSeidelG.\n49\n\n\nhttp://orcid.org/0000-0002-7536-9393\nSeiffertM.\n43\n\n\nhttp://orcid.org/0000-0002-0211-2861\nSerranoS.\n80\n81\n82\n\n\nhttp://orcid.org/0000-0002-0995-7146\nSirignanoC.\n78\n36\n\n\nhttp://orcid.org/0000-0003-2626-2853\nSirriG.\n8\n\n\nhttp://orcid.org/0000-0002-9706-5104\nStancoL.\n36\n\n\nhttp://orcid.org/0000-0003-2592-0113\nSuraceC.\n60\n\n\nhttp://orcid.org/0000-0002-1336-8328\nTallada-Cresp\u00edP.\n83\n20\n\n\nhttp://orcid.org/0000-0001-7475-9894\nTavagnaccoD.\n37\n\n\nTaylorA. N.\n24\n\n\nTerenoI.\n31\n84\n\n\nhttp://orcid.org/0000-0002-2997-4859\nToledo-MoreoR.\n85\n\n\nhttp://orcid.org/0000-0003-1160-1517\nTorradeflotF.\n20\n83\n\n\nValentijnE. A.\n86\n\n\nhttp://orcid.org/0000-0002-1170-0104\nValenzianoL.\n5\n87\n\n\nhttp://orcid.org/0000-0001-6512-6358\nVassalloT.\n41\n37\n\n\nhttp://orcid.org/0000-0003-2387-1194\nVeropalumboA.\n4\n12\n\n\nhttp://orcid.org/0000-0002-4749-2984\nWangY.\n88\n\n\nhttp://orcid.org/0000-0003-0396-1192\nZaccheiA.\n37\n89\n\n\nhttp://orcid.org/0000-0002-2318-301X\nZamoraniG.\n5\n\n\nhttp://orcid.org/0000-0003-1962-9805\nZoubianJ.\n38\n\n\nhttp://orcid.org/0000-0002-5845-8132\nZuccaE.\n5\n\n\nhttp://orcid.org/0000-0002-0857-0732\nBivianoA.\n37\n89\n\n\nhttp://orcid.org/0000-0003-3278-4607\nBolzonellaM.\n5\n\n\nhttp://orcid.org/0000-0001-7387-2633\nBoucaudA.\n64\n\n\nhttp://orcid.org/0000-0002-8201-1525\nBozzoE.\n33\n\n\nhttp://orcid.org/0000-0002-3005-5796\nBuriganaC.\n90\n87\n\n\nColodro-CondeC.\n76\n\n\nhttp://orcid.org/0000-0002-6220-9104\nDe LuciaG.\n37\n\n\nDi FerdinandoD.\n8\n\n\nEscartin VigoJ. A.\n9\n\n\nhttp://orcid.org/0000-0003-2212-367X\nFarinelliR.\n5\n\n\nhttp://orcid.org/0000-0003-4689-3134\nGracia-CarpioJ.\n9\n\n\nhttp://orcid.org/0000-0003-2384-2377\nMainettiG.\n91\n\n\nhttp://orcid.org/0000-0002-6943-7732\nMartinelliM.\n22\n92\n\n\nhttp://orcid.org/0000-0001-8196-1548\nMauriN.\n23\n8\n\n\nhttp://orcid.org/0000-0001-8524-4968\nNeissnerC.\n19\n20\n\n\nhttp://orcid.org/0000-0002-4823-3757\nSakrZ.\n93\n1\n94\n\n\nhttp://orcid.org/0009-0008-3864-940X\nScottezV.\n65\n95\n\n\nhttp://orcid.org/0000-0002-4254-5901\nTentiM.\n8\n\n\nhttp://orcid.org/0000-0002-2642-5707\nVielM.\n89\n37\n96\n97\n98\n\n\nhttp://orcid.org/0009-0000-8199-5860\nWiesmannM.\n42\n\n\nhttp://orcid.org/0000-0002-2407-7956\nAkramiY.\n99\n100\n\n\nhttp://orcid.org/0000-0001-7232-5152\nAllevatoV.\n14\n\n\nhttp://orcid.org/0000-0002-3579-9583\nAnselmiS.\n36\n78\n101\n\n\nhttp://orcid.org/0000-0002-8211-1630\nBaccigalupiC.\n96\n37\n97\n89\n\n\nhttp://orcid.org/0000-0001-5028-3035\nBalaguera-AntolinezA.\n76\n77\n\n\nhttp://orcid.org/0000-0003-4481-3559\nBallardiniM.\n102\n5\n103\n\n\nhttp://orcid.org/0000-0002-9622-7167\nBlotL.\n104\n101\n\n\nhttp://orcid.org/0000-0001-6151-6439\nBorganiS.\n105\n89\n37\n97\n\n\nhttp://orcid.org/0000-0002-6503-5218\nBrutonS.\n106\n\n\nhttp://orcid.org/0000-0001-6679-2600\nCabanacR.\n1\n\n\nCalabroA.\n22\n\n\nhttp://orcid.org/0000-0003-2796-2149\nCanas-HerreraG.\n66\n107\n\n\nhttp://orcid.org/0000-0002-9200-7167\nCappiA.\n5\n63\n\n\nCarvalhoC. S.\n84\n\n\nhttp://orcid.org/0000-0001-6831-0687\nCastignaniG.\n5\n\n\nhttp://orcid.org/0000-0002-6292-3228\nCastroT.\n37\n97\n89\n98\n\n\nhttp://orcid.org/0000-0001-6965-7789\nChambersK. C.\n108\n\n\nhttp://orcid.org/0000-0002-9843-723X\nContariniS.\n9\n61\n\n\nhttp://orcid.org/0000-0002-3892-0190\nCoorayA. R.\n109\n\n\nCouponJ.\n33\n\n\nhttp://orcid.org/0000-0003-3269-1718\nDaviniS.\n12\n\n\nDe CaroB.\n36\n78\n\n\nde la TorreS.\n60\n\n\nDesprezG.\n110\n\n\nhttp://orcid.org/0000-0003-0748-4768\nD\u00edaz-S\u00e1nchezA.\n111\n\n\nhttp://orcid.org/0000-0003-2863-5895\nDi DomizioS.\n11\n12\n\n\nhttp://orcid.org/0000-0002-9767-3839\nDoleH.\n35\n\n\nhttp://orcid.org/0000-0002-2847-7498\nEscoffierS.\n38\n\n\nhttp://orcid.org/0009-0005-5266-4110\nFerrariA. G.\n23\n8\n\n\nhttp://orcid.org/0000-0002-3021-2851\nFerreiraP. G.\n112\n\n\nhttp://orcid.org/0000-0002-1295-1132\nFerreroI.\n42\n\n\nhttp://orcid.org/0000-0002-6694-3269\nFinelliF.\n5\n87\n\n\nhttp://orcid.org/0000-0002-8486-8856\nGabarraL.\n112\n\n\nhttp://orcid.org/0000-0001-8159-8208\nGangaK.\n64\n\n\nhttp://orcid.org/0000-0002-9370-8360\nGarc\u00eda-BellidoJ.\n99\n\n\nhttp://orcid.org/0000-0001-9632-0815\nGaztanagaE.\n81\n80\n113\n\n\nhttp://orcid.org/0000-0002-3129-2814\nGiacominiF.\n8\n\n\nhttp://orcid.org/0000-0002-0236-919X\nGozaliaslG.\n114\n53\n\n\nhttp://orcid.org/0000-0002-9814-3338\nHildebrandtH.\n115\n\n\nhttp://orcid.org/0009-0004-5252-185X\nJimenez MunozA.\n116\n\n\nhttp://orcid.org/0000-0002-3010-8333\nKajavaJ. J. E.\n117\n118\n\n\nhttp://orcid.org/0000-0002-4008-6078\nKansalV.\n119\n120\n\n\nhttp://orcid.org/0000-0002-4927-0816\nKaragiannisD.\n121\n122\n\n\nKirkpatrickC. C.\n50\n\n\nhttp://orcid.org/0000-0003-0610-5252\nLegrandL.\n123\n\n\nLibetG.\n74\n\n\nhttp://orcid.org/0000-0002-4371-0876\nLoureiroA.\n124\n125\n\n\nhttp://orcid.org/0000-0002-5385-2763\nMacias-PerezJ.\n116\n\n\nhttp://orcid.org/0000-0003-4020-4836\nMaggioG.\n37\n\n\nhttp://orcid.org/0000-0001-9158-4838\nMagliocchettiM.\n34\n\n\nhttp://orcid.org/0000-0002-4803-2381\nMannucciF.\n126\n\n\nhttp://orcid.org/0000-0002-6065-3025\nMaoliR.\n127\n22\n\n\nhttp://orcid.org/0000-0002-4886-9261\nMartinsC. J. A. P.\n128\n16\n\n\nMatthewS.\n24\n\n\nhttp://orcid.org/0000-0002-8406-0857\nMaurinL.\n35\n\n\nhttp://orcid.org/0000-0003-3167-2574\nMetcalfR. B.\n61\n5\n\n\nMigliaccioM.\n129\n130\n\n\nhttp://orcid.org/0000-0003-2083-7564\nMonacoP.\n105\n37\n97\n89\n\n\nhttp://orcid.org/0000-0003-3314-8936\nMorettiC.\n96\n98\n37\n89\n97\n\n\nMorganteG.\n5\n\n\nhttp://orcid.org/0000-0001-9070-3102\nNadathurS.\n113\n\n\nhttp://orcid.org/0000-0003-3983-8778\nWaltonN. A.\n131\n\n\nhttp://orcid.org/0000-0002-9712-977X\nPatriziiL.\n8\n\n\nhttp://orcid.org/0000-0003-0726-2268\nPezzottaA.\n9\n\n\nhttp://orcid.org/0000-0001-5442-2530\nP\u00f6ntinenM.\n53\n\n\nPopaV.\n75\n\n\nhttp://orcid.org/0000-0002-7797-2508\nPorcianiC.\n59\n\n\nhttp://orcid.org/0000-0002-0757-5195\nPotterD.\n132\n\n\nhttp://orcid.org/0000-0003-2525-7761\nRissoI.\n133\n\n\nhttp://orcid.org/0000-0001-8106-2702\nRocciP.-F.\n35\n\n\nhttp://orcid.org/0000-0003-0973-4804\nSahl\u00e9nM.\n134\n\n\nhttp://orcid.org/0000-0003-1198-831X\nS\u00e1nchezA. G.\n9\n\n\nSchewtschenkoJ. A.\n24\n\n\nhttp://orcid.org/0000-0001-7055-8104\nSchneiderA.\n132\n\n\nhttp://orcid.org/0000-0003-0473-1567\nSefusattiE.\n37\n89\n97\n\n\nhttp://orcid.org/0000-0003-0302-0325\nSerenoM.\n5\n8\n\n\nhttp://orcid.org/0000-0001-7443-1047\nSteinwagnerJ.\n9\n\n\nhttp://orcid.org/0000-0002-9696-7931\nTessoreN.\n135\n\n\nTesteraG.\n12\n\n\nhttp://orcid.org/0000-0001-7689-0933\nTeyssierR.\n136\n\n\nhttp://orcid.org/0000-0003-3631-7176\nToftS.\n47\n137\n\n\nhttp://orcid.org/0000-0002-7275-9193\nTosiS.\n11\n4\n12\n\n\nhttp://orcid.org/0000-0003-0239-4595\nTrojaA.\n78\n36\n\n\nTucciM.\n33\n\n\nhttp://orcid.org/0000-0001-6225-3693\nValiviitaJ.\n53\n54\n\n\nhttp://orcid.org/0000-0003-0898-2216\nVerganiD.\n5\n\n\nhttp://orcid.org/0000-0002-1886-8348\nVerzaG.\n138\n139\n\n\n"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut de Recherche en Astrophysique et Plan\u00e9tologie (IRAP), Universit\u00e9 de Toulouse, CNRS, UPS, CNES, 14 Av. Edouard Belin, 31400, Toulouse, France"
+        }
+      ],
+      "name": {
+        "given_name": "F.",
+        "surname": "Dournac"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut de Recherche en Astrophysique et Plan\u00e9tologie (IRAP), Universit\u00e9 de Toulouse, CNRS, UPS, CNES, 14 Av. Edouard Belin, 31400, Toulouse, France"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Blanchard"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Paris-Saclay, CNRS/IN2P3, IJCLab, 91405, Orsay, France"
+        },
+        {
+          "affPubRaw": "Institut de Recherche en Astrophysique et Plan\u00e9tologie (IRAP), Universit\u00e9 de Toulouse, CNRS, UPS, CNES, 14 Av. Edouard Belin, 31400, Toulouse, France"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Ili\u0107"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut de Recherche en Astrophysique et Plan\u00e9tologie (IRAP), Universit\u00e9 de Toulouse, CNRS, UPS, CNES, 14 Av. Edouard Belin, 31400, Toulouse, France"
+        }
+      ],
+      "name": {
+        "given_name": "B.",
+        "surname": "Lamine"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut de Recherche en Astrophysique et Plan\u00e9tologie (IRAP), Universit\u00e9 de Toulouse, CNRS, UPS, CNES, 14 Av. Edouard Belin, 31400, Toulouse, France"
+        }
+      ],
+      "name": {
+        "given_name": "I.",
+        "surname": "Tutusaus"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "School of Mathematics and Physics, University of Surrey, Guildford, Surrey, GU2 7XH, UK"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Amara"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Brera, Via Brera 28, 20122, Milano, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Andreon"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "N.",
+        "surname": "Auricchio"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Paris-Saclay, Universit\u00e9 Paris Cit\u00e9, CEA, CNRS, AIM, 91191, Gif-sur-Yvette, France"
+        }
+      ],
+      "name": {
+        "given_name": "H.",
+        "surname": "Aussel"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia, Universit\u00e0 di Bologna, Via Gobetti 93/2, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Baldi"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Bardelli"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Max Planck Institute for Extraterrestrial Physics, Giessenbachstr. 1, 85748, Garching, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "C.",
+        "surname": "Bodendorf"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astrofisico di Torino, Via Osservatorio 20, 10025, Pino Torinese (TO), Italy"
+        }
+      ],
+      "name": {
+        "given_name": "D.",
+        "surname": "Bonino"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica, Universit\u00e0 di Genova, Via Dodecaneso 33, 16146, Genova, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Genova, Via Dodecaneso 33, 16146, Genova, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Brera, Via Brera 28, 20122, Milano, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Branchini"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut de Recherche en Astrophysique et Plan\u00e9tologie (IRAP), Universit\u00e9 de Toulouse, CNRS, UPS, CNES, 14 Av. Edouard Belin, 31400, Toulouse, France"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Brau-Nogue"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics \u201cE. Pancini\u201d, University Federico II, Via Cinthia 6, 80126, Napoli, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Capodimonte, Via Moiariello 16, 80131, Napoli, Italy"
+        },
+        {
+          "affPubRaw": "INFN section of Naples, Via Cinthia 6, 80126, Napoli, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Brescia"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Instituto de Astrof\u00edsica e Ci\u00eancias do Espa\u00e7o, Universidade do Porto, CAUP, Rua das Estrelas, PT4150-762, Porto, Portugal"
+        }
+      ],
+      "name": {
+        "given_name": "J.",
+        "surname": "Brinchmann"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica, Universit\u00e0 degli Studi di Torino, Via P. Giuria 1, 10125, Torino, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Torino, Via P. Giuria 1, 10125, Torino, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio Astrofisico di Torino, Via Osservatorio 20, 10025, Pino Torinese (TO), Italy"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Camera"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astrofisico di Torino, Via Osservatorio 20, 10025, Pino Torinese (TO), Italy"
+        }
+      ],
+      "name": {
+        "given_name": "V.",
+        "surname": "Capobianco"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut de F\u00edsica d\u2019Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, 08193, Bellaterra (Barcelona), Spain"
+        },
+        {
+          "affPubRaw": "Port d\u2019Informaci\u00f3 Cient\u00edfica, Campus UAB, C. Albareda s/n, 08193, Bellaterra (Barcelona), Spain"
+        }
+      ],
+      "name": {
+        "given_name": "J.",
+        "surname": "Carretero"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute for Theoretical Particle Physics and Cosmology (TTK), RWTH Aachen University, 52056, Aachen, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Casas"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Roma, Via Frascati 33, 00078, Monteporzio Catone, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Castellano"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Capodimonte, Via Moiariello 16, 80131, Napoli, Italy"
+        },
+        {
+          "affPubRaw": "INFN section of Naples, Via Cinthia 6, 80126, Napoli, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Cavuoti"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cAugusto Righi\u201d - Alma Mater Studiorum Universit\u00e0 di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Cimatti"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute for Astronomy, University of Edinburgh, Royal Observatory, Blackford Hill, Edinburgh, EH9 3HJ, UK"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Congedo"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Jodrell Bank Centre for Astrophysics, Department of Physics and Astronomy, University of Manchester, Oxford Road, Manchester, M13 9PL, UK"
+        }
+      ],
+      "name": {
+        "given_name": "C. J.",
+        "surname": "Conselice"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "European Space Agency/ESRIN, Largo Galileo Galilei 1, 00044, Frascati, Roma, Italy"
+        },
+        {
+          "affPubRaw": "ESAC/ESA, Camino Bajo del Castillo, s/n., Urb. Villafranca del Castillo, 28692, Villanueva de la Ca\u00f1ada, Madrid, Spain"
+        }
+      ],
+      "name": {
+        "given_name": "L.",
+        "surname": "Conversi"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Claude Bernard Lyon 1, CNRS/IN2P3, IP2I Lyon, UMR 5822, 69100, Villeurbanne, France"
+        }
+      ],
+      "name": {
+        "given_name": "Y.",
+        "surname": "Copin"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute of Physics, Laboratory of Astrophysics, Ecole Polytechnique F\u00e9d\u00e9rale de Lausanne (EPFL), Observatoire de Sauverny, 1290, Versoix, Switzerland"
+        }
+      ],
+      "name": {
+        "given_name": "F.",
+        "surname": "Courbin"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "UCB Lyon 1, CNRS/IN2P3, IUF, IP2I Lyon, 4 rue Enrico Fermi, 69622, Villeurbanne, France"
+        }
+      ],
+      "name": {
+        "given_name": "H. M.",
+        "surname": "Courtois"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Departamento de F\u00edsica, Faculdade de Ci\u00eancias, Universidade de Lisboa, Edif\u00edcio C8, Campo Grande, PT1749-016, Lisboa, Portugal"
+        },
+        {
+          "affPubRaw": "Instituto de Astrof\u00edsica e Ci\u00eancias do Espa\u00e7o, Faculdade de Ci\u00ean- cias, Universidade de Lisboa, Campo Grande, 1749-016, Lisboa, Portugal"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Da Silva"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Astronomy, University of Geneva, ch. d\u2019Ecogia 16, 1290, Versoix, Switzerland"
+        }
+      ],
+      "name": {
+        "given_name": "H.",
+        "surname": "Degaudenzi"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Istituto di Astrofisica e Planetologia Spaziali, via del Fosso del Cavaliere, 100, 00100, Roma, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "A. M.",
+        "surname": "Di Giorgio"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Departamento de F\u00edsica, Faculdade de Ci\u00eancias, Universidade de Lisboa, Edif\u00edcio C8, Campo Grande, PT1749-016, Lisboa, Portugal"
+        },
+        {
+          "affPubRaw": "Instituto de Astrof\u00edsica e Ci\u00eancias do Espa\u00e7o, Faculdade de Ci\u00ean- cias, Universidade de Lisboa, Campo Grande, 1749-016, Lisboa, Portugal"
+        }
+      ],
+      "name": {
+        "given_name": "J.",
+        "surname": "Dinis"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Paris-Saclay, CNRS, Institut d\u2019astrophysique spatiale, 91405, Orsay, France"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Douspis"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Astronomy, University of Geneva, ch. d\u2019Ecogia 16, 1290, Versoix, Switzerland"
+        }
+      ],
+      "name": {
+        "given_name": "F.",
+        "surname": "Dubath"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "ESAC/ESA, Camino Bajo del Castillo, s/n., Urb. Villafranca del Castillo, 28692, Villanueva de la Ca\u00f1ada, Madrid, Spain"
+        }
+      ],
+      "name": {
+        "given_name": "X.",
+        "surname": "Dupac"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INFN-Padova, Via Marzolo 8, 35131, Padova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Dusini"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Claude Bernard Lyon 1, CNRS/IN2P3, IP2I Lyon, UMR 5822, 69100, Villeurbanne, France"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Ealet"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Istituto di Astrofisica e Planetologia Spaziali, via del Fosso del Cavaliere, 100, 00100, Roma, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Farina"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Paris-Saclay, Universit\u00e9 Paris Cit\u00e9, CEA, CNRS, AIM, 91191, Gif-sur-Yvette, France"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Farrens"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Claude Bernard Lyon 1, CNRS/IN2P3, IP2I Lyon, UMR 5822, 69100, Villeurbanne, France"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Ferriol"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Frailis"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Franceschi"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Galeotta"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Aix-Marseille Universit\u00e9, CNRS/IN2P3, CPPM, Marseille, France"
+        }
+      ],
+      "name": {
+        "given_name": "W.",
+        "surname": "Gillard"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute for Astronomy, University of Edinburgh, Royal Observatory, Blackford Hill, Edinburgh, EH9 3HJ, UK"
+        }
+      ],
+      "name": {
+        "given_name": "B.",
+        "surname": "Gillis"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "Istituto Nazionale di Fisica Nucleare, Sezione di Bologna, Via Irnerio 46, 40126, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "C.",
+        "surname": "Giocoli"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Brera, Via Brera 28, 20122, Milano, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "B. R.",
+        "surname": "Granett"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Padova, Via dell\u2019Osservatorio 5, 35122, Padova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Grazian"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Max Planck Institute for Extraterrestrial Physics, Giessenbachstr. 1, 85748, Garching, Germany"
+        },
+        {
+          "affPubRaw": "Universit\u00e4ts-Sternwarte M\u00fcnchen, Fakult\u00e4t f\u00fcr Physik, Ludwig-Maximilians-Universit\u00e4t M\u00fcnchen, Scheinerstrasse 1, 81679, M\u00fcnchen, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "F.",
+        "surname": "Grupp"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute of Theoretical Astrophysics, University of Oslo, PO Box 1029, Blindern, 0315, Oslo, Norway"
+        }
+      ],
+      "name": {
+        "given_name": "S. V. H.",
+        "surname": "Haugan"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Jet Propulsion Laboratory, California Institute of Technology, 4800 Oak Grove Drive, Pasadena, CA, 91109, USA"
+        }
+      ],
+      "name": {
+        "given_name": "W.",
+        "surname": "Holmes"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, Lancaster University, Lancaster, LA1 4YB, UK"
+        }
+      ],
+      "name": {
+        "given_name": "I.",
+        "surname": "Hook"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Felix Hormuth Engineering, Goethestr. 17, 69181, Leimen, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "F.",
+        "surname": "Hormuth"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Technical University of Denmark, Elektrovej 327, 2800 Kgs., Lyngby, Denmark"
+        },
+        {
+          "affPubRaw": "Cosmic Dawn Center (DAWN), Denmark"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Hornstrup"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut d\u2019Astrophysique de Paris, UMR 7095, CNRS, and Sorbonne Universit\u00e9, 98 bis boulevard Arago, 75014, Paris, France"
+        }
+      ],
+      "name": {
+        "given_name": "P.",
+        "surname": "Hudelot"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Max-Planck-Institut f\u00fcr Astronomie, K\u00f6nigstuhl 17, 69117, Heidelberg, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "K.",
+        "surname": "Jahnke"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics and Helsinki Institute of Physics, Gustaf H\u00e4llstr\u00f6min katu 2, 00014 University of Helsinki, Finland"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Keih\u00e4nen"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Aix-Marseille Universit\u00e9, CNRS/IN2P3, CPPM, Marseille, France"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Kermiche"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Jet Propulsion Laboratory, California Institute of Technology, 4800 Oak Grove Drive, Pasadena, CA, 91109, USA"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Kiessling"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "AIM, CEA, CNRS, Universit\u00e9 Paris-Saclay, Universit\u00e9 de Paris, 91191, Gif-sur-Yvette, France"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Kilbinger"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Claude Bernard Lyon 1, CNRS/IN2P3, IP2I Lyon, UMR 5822, 69100, Villeurbanne, France"
+        }
+      ],
+      "name": {
+        "given_name": "B.",
+        "surname": "Kubik"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e4ts-Sternwarte M\u00fcnchen, Fakult\u00e4t f\u00fcr Physik, Ludwig-Maximilians-Universit\u00e4t M\u00fcnchen, Scheinerstrasse 1, 81679, M\u00fcnchen, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "K\u00fcmmel"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 de Gen\u00e8ve, D\u00e9partement de Physique Th\u00e9orique and Centre for Astroparticle Physics, 24 quai Ernest-Ansermet, 1211, Gen\u00e8ve 4, Switzerland"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Kunz"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, P.O. Box 64, 00014, University of Helsinki, Finland"
+        },
+        {
+          "affPubRaw": "Helsinki Institute of Physics, Gustaf H\u00e4llstr\u00f6min katu 2, University of Helsinki, Helsinki, Finland"
+        }
+      ],
+      "name": {
+        "given_name": "H.",
+        "surname": "Kurki-Suonio"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astrofisico di Torino, Via Osservatorio 20, 10025, Pino Torinese (TO), Italy"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Ligori"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute of Theoretical Astrophysics, University of Oslo, PO Box 1029, Blindern, 0315, Oslo, Norway"
+        }
+      ],
+      "name": {
+        "given_name": "P. B.",
+        "surname": "Lilje"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, P.O. Box 64, 00014, University of Helsinki, Finland"
+        },
+        {
+          "affPubRaw": "Helsinki Institute of Physics, Gustaf H\u00e4llstr\u00f6min katu 2, University of Helsinki, Helsinki, Finland"
+        }
+      ],
+      "name": {
+        "given_name": "V.",
+        "surname": "Lindholm"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "NOVA optical infrared instrumentation group at ASTRON, Oude Hoogeveensedijk 4, 7991PD, Dwingeloo, The Netherlands"
+        }
+      ],
+      "name": {
+        "given_name": "I.",
+        "surname": "Lloro"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica \u201cAldo Pontremoli\u201d, Universit\u00e0 degli Studi di Milano, Via Celoria 16, 20133, Milano, Italy"
+        },
+        {
+          "affPubRaw": "INAF-IASF Milano, Via Alfonso Corti 12, 20133, Milano, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Milano, Via Celoria 16, 20133, Milano, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "D.",
+        "surname": "Maino"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Maiorano"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "O.",
+        "surname": "Mansutti"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e4t Bonn, Argelander-Institut f\u00fcr Astronomie, Auf dem H\u00fcgel 71, 53121, Bonn, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "O.",
+        "surname": "Marggraf"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Jet Propulsion Laboratory, California Institute of Technology, 4800 Oak Grove Drive, Pasadena, CA, 91109, USA"
+        }
+      ],
+      "name": {
+        "given_name": "K.",
+        "surname": "Markovic"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Aix-Marseille Universit\u00e9, CNRS, CNES, LAM, Marseille, France"
+        }
+      ],
+      "name": {
+        "given_name": "N.",
+        "surname": "Martinet"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cAugusto Righi\u201d - Alma Mater Studiorum Universit\u00e0 di Bologna, via Piero Gobetti 93/2, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "F.",
+        "surname": "Marulli"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, Centre for Extragalactic Astronomy, Durham University, South Road, DH1 3LE, UK"
+        }
+      ],
+      "name": {
+        "given_name": "R.",
+        "surname": "Massey"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 C\u00f4te d\u2019Azur, Observatoire de la C\u00f4te d\u2019Azur, CNRS, Laboratoire Lagrange, Bd de l\u2019Observatoire, CS 34229, 06304, Nice cedex 4, France"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Maurogordato"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Medinaceli"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Paris Cit\u00e9, CNRS, Astroparticule et Cosmologie, 75013, Paris, France"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Mei"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut d\u2019Astrophysique de Paris, 98bis Boulevard Arago, 75014, Paris, France"
+        },
+        {
+          "affPubRaw": "Institut d\u2019Astrophysique de Paris, UMR 7095, CNRS, and Sorbonne Universit\u00e9, 98 bis boulevard Arago, 75014, Paris, France"
+        }
+      ],
+      "name": {
+        "given_name": "Y.",
+        "surname": "Mellier"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Meneghetti"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Roma, Via Frascati 33, 00078, Monteporzio Catone, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Merlin"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute of Physics, Laboratory of Astrophysics, Ecole Polytechnique F\u00e9d\u00e9rale de Lausanne (EPFL), Observatoire de Sauverny, 1290, Versoix, Switzerland"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Meylan"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cAugusto Righi\u201d - Alma Mater Studiorum Universit\u00e0 di Bologna, via Piero Gobetti 93/2, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Moresco"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cAugusto Righi\u201d - Alma Mater Studiorum Universit\u00e0 di Bologna, via Piero Gobetti 93/2, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "L.",
+        "surname": "Moscardini"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Munari"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "European Space Agency/ESTEC, Keplerlaan 1, 2201 AZ, Noordwijk, The Netherlands"
+        }
+      ],
+      "name": {
+        "given_name": "S.-M.",
+        "surname": "Niemi"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "School of Mathematics, Statistics and Physics, Newcastle University, Herschel Building, Newcastle-upon-Tyne, NE1 7RU, UK"
+        },
+        {
+          "affPubRaw": "Department of Physics, Institute for Computational Cosmology, Durham University, South Road, DH1 3LE, UK"
+        }
+      ],
+      "name": {
+        "given_name": "J. W.",
+        "surname": "Nightingale"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut de F\u00edsica d\u2019Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, 08193, Bellaterra (Barcelona), Spain"
+        }
+      ],
+      "name": {
+        "given_name": "C.",
+        "surname": "Padilla"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Astronomy, University of Geneva, ch. d\u2019Ecogia 16, 1290, Versoix, Switzerland"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Paltani"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "F.",
+        "surname": "Pasian"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics and Astronomy, University of Aarhus, Ny Munkegade 120, 8000, Aarhus C, Denmark"
+        }
+      ],
+      "name": {
+        "given_name": "K.",
+        "surname": "Pedersen"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Waterloo Centre for Astrophysics, University of Waterloo, Waterloo, Ontario, N2L 3G1, Canada"
+        },
+        {
+          "affPubRaw": "Department of Physics and Astronomy, University of Waterloo, Waterloo, Ontario, N2L 3G1, Canada"
+        },
+        {
+          "affPubRaw": "Perimeter Institute for Theoretical Physics, Waterloo, Ontario, N2L 2Y5, Canada"
+        }
+      ],
+      "name": {
+        "given_name": "W. J.",
+        "surname": "Percival"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "European Space Agency/ESTEC, Keplerlaan 1, 2201 AZ, Noordwijk, The Netherlands"
+        }
+      ],
+      "name": {
+        "given_name": "V.",
+        "surname": "Pettorino"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Paris-Saclay, Universit\u00e9 Paris Cit\u00e9, CEA, CNRS, AIM, 91191, Gif-sur-Yvette, France"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Pires"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Space Science Data Center, Italian Space Agency, via del Politecnico snc, 00133, Roma, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Polenta"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Centre National d\u2019Etudes Spatiales \u2013 Centre spatial de Toulouse, 18 avenue Edouard Belin, 31401, Toulouse Cedex 9, France"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Poncet"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute of Space Science, Str. Atomistilor, nr. 409 M\u0103gurele, Ilfov, 077125, Romania"
+        }
+      ],
+      "name": {
+        "given_name": "L. A.",
+        "surname": "Popa"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "L.",
+        "surname": "Pozzetti"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Max Planck Institute for Extraterrestrial Physics, Giessenbachstr. 1, 85748, Garching, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "F.",
+        "surname": "Raison"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Instituto de Astrof\u00edsica de Canarias, Calle V\u00eda L\u00e1ctea s/n, 38204, San Crist\u00f3bal de La Laguna, Tenerife, Spain"
+        },
+        {
+          "affPubRaw": "Departamento de Astrof\u00edsica, Universidad de La Laguna, 38206, La Laguna, Tenerife, Spain"
+        }
+      ],
+      "name": {
+        "given_name": "R.",
+        "surname": "Rebolo"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cG. Galilei\u201d, Universit\u00e0 di Padova, Via Marzolo 8, 35131, Padova, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Padova, Via Marzolo 8, 35131, Padova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Renzi"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Jet Propulsion Laboratory, California Institute of Technology, 4800 Oak Grove Drive, Pasadena, CA, 91109, USA"
+        }
+      ],
+      "name": {
+        "given_name": "J.",
+        "surname": "Rhodes"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Capodimonte, Via Moiariello 16, 80131, Napoli, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Riccio"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Romelli"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Roncarelli"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia, Universit\u00e0 di Bologna, Via Gobetti 93/2, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Rossetti"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e4ts-Sternwarte M\u00fcnchen, Fakult\u00e4t f\u00fcr Physik, Ludwig-Maximilians-Universit\u00e4t M\u00fcnchen, Scheinerstrasse 1, 81679, M\u00fcnchen, Germany"
+        },
+        {
+          "affPubRaw": "Max Planck Institute for Extraterrestrial Physics, Giessenbachstr. 1, 85748, Garching, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "R.",
+        "surname": "Saglia"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Departamento de F\u00edsica, FCFM, Universidad de Chile, Blanco Encalada 2008, Santiago, Chile"
+        }
+      ],
+      "name": {
+        "given_name": "D.",
+        "surname": "Sapone"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e4t Bonn, Argelander-Institut f\u00fcr Astronomie, Auf dem H\u00fcgel 71, 53121, Bonn, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "P.",
+        "surname": "Schneider"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Aix-Marseille Universit\u00e9, CNRS/IN2P3, CPPM, Marseille, France"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Secroun"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Max-Planck-Institut f\u00fcr Astronomie, K\u00f6nigstuhl 17, 69117, Heidelberg, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Seidel"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Jet Propulsion Laboratory, California Institute of Technology, 4800 Oak Grove Drive, Pasadena, CA, 91109, USA"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Seiffert"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut d\u2019Estudis Espacials de Catalunya (IEEC), Edifici RDIT, Campus UPC, 08860, Castelldefels, Barcelona, Spain"
+        },
+        {
+          "affPubRaw": "Institute of Space Sciences (ICE, CSIC), Campus UAB, Carrer de Can Magrans, s/n, 08193, Barcelona, Spain"
+        },
+        {
+          "affPubRaw": "Satlantis, University Science Park, Sede Bld 48940, Leioa-Bilbao, Spain"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Serrano"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cG. Galilei\u201d, Universit\u00e0 di Padova, Via Marzolo 8, 35131, Padova, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Padova, Via Marzolo 8, 35131, Padova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "C.",
+        "surname": "Sirignano"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INFN-Sezione di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Sirri"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INFN-Padova, Via Marzolo 8, 35131, Padova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "L.",
+        "surname": "Stanco"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Aix-Marseille Universit\u00e9, CNRS, CNES, LAM, Marseille, France"
+        }
+      ],
+      "name": {
+        "given_name": "C.",
+        "surname": "Surace"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Centro de Investigaciones Energ\u00e9ticas, Medioambientales y Tec- nol\u00f3gicas (CIEMAT), Avenida Complutense 40, 28040, Madrid, Spain"
+        },
+        {
+          "affPubRaw": "Port d\u2019Informaci\u00f3 Cient\u00edfica, Campus UAB, C. Albareda s/n, 08193, Bellaterra (Barcelona), Spain"
+        }
+      ],
+      "name": {
+        "given_name": "P.",
+        "surname": "Tallada-Cresp\u00ed"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "D.",
+        "surname": "Tavagnacco"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute for Astronomy, University of Edinburgh, Royal Observatory, Blackford Hill, Edinburgh, EH9 3HJ, UK"
+        }
+      ],
+      "name": {
+        "given_name": "A. N.",
+        "surname": "Taylor"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Departamento de F\u00edsica, Faculdade de Ci\u00eancias, Universidade de Lisboa, Edif\u00edcio C8, Campo Grande, PT1749-016, Lisboa, Portugal"
+        },
+        {
+          "affPubRaw": "Instituto de Astrof\u00edsica e Ci\u00eancias do Espa\u00e7o, Faculdade de Ci\u00ean- cias, Universidade de Lisboa, Tapada da Ajuda, 1349-018, Lisboa, Portugal"
+        }
+      ],
+      "name": {
+        "given_name": "I.",
+        "surname": "Tereno"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universidad Polit\u00e9cnica de Cartagena, Departamento de Electr\u00f3nica y Tecnolog\u00eda de Computadoras, Plaza del Hospital 1, 30202, Cartagena, Spain"
+        }
+      ],
+      "name": {
+        "given_name": "R.",
+        "surname": "Toledo-Moreo"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Port d\u2019Informaci\u00f3 Cient\u00edfica, Campus UAB, C. Albareda s/n, 08193, Bellaterra (Barcelona), Spain"
+        },
+        {
+          "affPubRaw": "Centro de Investigaciones Energ\u00e9ticas, Medioambientales y Tec- nol\u00f3gicas (CIEMAT), Avenida Complutense 40, 28040, Madrid, Spain"
+        }
+      ],
+      "name": {
+        "given_name": "F.",
+        "surname": "Torradeflot"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Kapteyn Astronomical Institute, University of Groningen, PO Box 800, 9700 AV, Groningen, The Netherlands"
+        }
+      ],
+      "name": {
+        "given_name": "E. A.",
+        "surname": "Valentijn"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Bologna, Via Irnerio 46, 40126, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "L.",
+        "surname": "Valenziano"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e4ts-Sternwarte M\u00fcnchen, Fakult\u00e4t f\u00fcr Physik, Ludwig-Maximilians-Universit\u00e4t M\u00fcnchen, Scheinerstrasse 1, 81679, M\u00fcnchen, Germany"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "T.",
+        "surname": "Vassallo"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Brera, Via Brera 28, 20122, Milano, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Genova, Via Dodecaneso 33, 16146, Genova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Veropalumbo"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Infrared Processing and Analysis Center, California Institute of Technology, Pasadena, CA, 91125, USA"
+        }
+      ],
+      "name": {
+        "given_name": "Y.",
+        "surname": "Wang"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "IFPU, Institute for Fundamental Physics of the Universe, via Beirut 2, 34151, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Zacchei"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Zamorani"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Aix-Marseille Universit\u00e9, CNRS/IN2P3, CPPM, Marseille, France"
+        }
+      ],
+      "name": {
+        "given_name": "J.",
+        "surname": "Zoubian"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Zucca"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "IFPU, Institute for Fundamental Physics of the Universe, via Beirut 2, 34151, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Biviano"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Bolzonella"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Paris Cit\u00e9, CNRS, Astroparticule et Cosmologie, 75013, Paris, France"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Boucaud"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Astronomy, University of Geneva, ch. d\u2019Ecogia 16, 1290, Versoix, Switzerland"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Bozzo"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF, Istituto di Radioastronomia, Via Piero Gobetti 101, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Bologna, Via Irnerio 46, 40126, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "C.",
+        "surname": "Burigana"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Instituto de Astrof\u00edsica de Canarias, Calle V\u00eda L\u00e1ctea s/n, 38204, San Crist\u00f3bal de La Laguna, Tenerife, Spain"
+        }
+      ],
+      "name": {
+        "given_name": "C.",
+        "surname": "Colodro-Conde"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "De Lucia"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INFN-Sezione di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "D.",
+        "surname": "Di Ferdinando"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Max Planck Institute for Extraterrestrial Physics, Giessenbachstr. 1, 85748, Garching, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "J. A.",
+        "surname": "Escartin Vigo"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "R.",
+        "surname": "Farinelli"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Max Planck Institute for Extraterrestrial Physics, Giessenbachstr. 1, 85748, Garching, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "J.",
+        "surname": "Gracia-Carpio"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Centre de Calcul de l\u2019IN2P3/CNRS, 21 avenue Pierre de Coubertin, 69627, Villeurbanne Cedex, France"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Mainetti"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Roma, Via Frascati 33, 00078, Monteporzio Catone, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Roma, Piazzale Aldo Moro, 2 - c/o Dipartimento di Fisica, Edificio G. Marconi, 00185, Roma, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Martinelli"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cAugusto Righi\u201d - Alma Mater Studiorum Universit\u00e0 di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "N.",
+        "surname": "Mauri"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut de F\u00edsica d\u2019Altes Energies (IFAE), The Barcelona Institute of Science and Technology, Campus UAB, 08193, Bellaterra (Barcelona), Spain"
+        },
+        {
+          "affPubRaw": "Port d\u2019Informaci\u00f3 Cient\u00edfica, Campus UAB, C. Albareda s/n, 08193, Bellaterra (Barcelona), Spain"
+        }
+      ],
+      "name": {
+        "given_name": "C.",
+        "surname": "Neissner"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut f\u00fcr Theoretische Physik, University of Heidelberg, Philosophenweg 16, 69120, Heidelberg, Germany"
+        },
+        {
+          "affPubRaw": "Institut de Recherche en Astrophysique et Plan\u00e9tologie (IRAP), Universit\u00e9 de Toulouse, CNRS, UPS, CNES, 14 Av. Edouard Belin, 31400, Toulouse, France"
+        },
+        {
+          "affPubRaw": "Universit\u00e9 St Joseph; Faculty of Sciences, Beirut, Lebanon"
+        }
+      ],
+      "name": {
+        "given_name": "Z.",
+        "surname": "Sakr"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut d\u2019Astrophysique de Paris, 98bis Boulevard Arago, 75014, Paris, France"
+        },
+        {
+          "affPubRaw": "Junia, EPA department, 41 Bd Vauban, 59800, Lille, France"
+        }
+      ],
+      "name": {
+        "given_name": "V.",
+        "surname": "Scottez"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INFN-Sezione di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Tenti"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "IFPU, Institute for Fundamental Physics of the Universe, via Beirut 2, 34151, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "SISSA, International School for Advanced Studies, Via Bonomea 265, 34136, Trieste TS, Italy"
+        },
+        {
+          "affPubRaw": "INFN, Sezione di Trieste, Via Valerio 2, 34127, Trieste TS, Italy"
+        },
+        {
+          "affPubRaw": "ICSC - Centro Nazionale di Ricerca in High Performance Computing, Big Data e Quantum Computing, Via Magnanelli 2, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Viel"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute of Theoretical Astrophysics, University of Oslo, PO Box 1029, Blindern, 0315, Oslo, Norway"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Wiesmann"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Instituto de F\u00edsica Te\u00f3rica UAM-CSIC, Campus de Cantoblanco, 28049, Madrid, Spain"
+        },
+        {
+          "affPubRaw": "CERCA/ISO, Department of Physics, Case Western Reserve University, 10900 Euclid Avenue, Cleveland, OH, 44106, USA"
+        }
+      ],
+      "name": {
+        "given_name": "Y.",
+        "surname": "Akrami"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Capodimonte, Via Moiariello 16, 80131, Napoli, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "V.",
+        "surname": "Allevato"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INFN-Padova, Via Marzolo 8, 35131, Padova, Italy"
+        },
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cG. Galilei\u201d, Universit\u00e0 di Padova, Via Marzolo 8, 35131, Padova, Italy"
+        },
+        {
+          "affPubRaw": "Laboratoire Univers et Th\u00e9orie, Observatoire de Paris, Universit\u00e9 PSL, Universit\u00e9 Paris Cit\u00e9, CNRS, 92190, Meudon, France"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Anselmi"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "SISSA, International School for Advanced Studies, Via Bonomea 265, 34136, Trieste TS, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "INFN, Sezione di Trieste, Via Valerio 2, 34127, Trieste TS, Italy"
+        },
+        {
+          "affPubRaw": "IFPU, Institute for Fundamental Physics of the Universe, via Beirut 2, 34151, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "C.",
+        "surname": "Baccigalupi"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Instituto de Astrof\u00edsica de Canarias, Calle V\u00eda L\u00e1ctea s/n, 38204, San Crist\u00f3bal de La Laguna, Tenerife, Spain"
+        },
+        {
+          "affPubRaw": "Departamento de Astrof\u00edsica, Universidad de La Laguna, 38206, La Laguna, Tenerife, Spain"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Balaguera-Antolinez"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Scienze della Terra, Universit\u00e0 degli Studi di Ferrara, Via Giuseppe Saragat 1, 44122, Ferrara, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "Istituto Nazionale di Fisica Nucleare, Sezione di Ferrara, Via Giuseppe Saragat 1, 44122, Ferrara, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Ballardini"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Kavli Institute for the Physics and Mathematics of the Universe (WPI), University of Tokyo, Kashiwa, Chiba, 277-8583, Japan"
+        },
+        {
+          "affPubRaw": "Laboratoire Univers et Th\u00e9orie, Observatoire de Paris, Universit\u00e9 PSL, Universit\u00e9 Paris Cit\u00e9, CNRS, 92190, Meudon, France"
+        }
+      ],
+      "name": {
+        "given_name": "L.",
+        "surname": "Blot"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica - Sezione di Astronomia, Universit\u00e0 di Trieste, Via Tiepolo 11, 34131, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "IFPU, Institute for Fundamental Physics of the Universe, via Beirut 2, 34151, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "INFN, Sezione di Trieste, Via Valerio 2, 34127, Trieste TS, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Borgani"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Minnesota Institute for Astrophysics, University of Minnesota, 116 Church St SE, Minneapolis, MN, 55455, USA"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Bruton"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institut de Recherche en Astrophysique et Plan\u00e9tologie (IRAP), Universit\u00e9 de Toulouse, CNRS, UPS, CNES, 14 Av. Edouard Belin, 31400, Toulouse, France"
+        }
+      ],
+      "name": {
+        "given_name": "R.",
+        "surname": "Cabanac"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Roma, Via Frascati 33, 00078, Monteporzio Catone, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Calabro"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "European Space Agency/ESTEC, Keplerlaan 1, 2201 AZ, Noordwijk, The Netherlands"
+        },
+        {
+          "affPubRaw": "Institute Lorentz, Leiden University, Niels Bohrweg 2, 2333 CA, Leiden, The Netherlands"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Canas-Herrera"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "Universit\u00e9 C\u00f4te d\u2019Azur, Observatoire de la C\u00f4te d\u2019Azur, CNRS, Laboratoire Lagrange, Bd de l\u2019Observatoire, CS 34229, 06304, Nice cedex 4, France"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Cappi"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Instituto de Astrof\u00edsica e Ci\u00eancias do Espa\u00e7o, Faculdade de Ci\u00ean- cias, Universidade de Lisboa, Tapada da Ajuda, 1349-018, Lisboa, Portugal"
+        }
+      ],
+      "name": {
+        "given_name": "C. S.",
+        "surname": "Carvalho"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Castignani"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "INFN, Sezione di Trieste, Via Valerio 2, 34127, Trieste TS, Italy"
+        },
+        {
+          "affPubRaw": "IFPU, Institute for Fundamental Physics of the Universe, via Beirut 2, 34151, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "ICSC - Centro Nazionale di Ricerca in High Performance Computing, Big Data e Quantum Computing, Via Magnanelli 2, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "T.",
+        "surname": "Castro"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute for Astronomy, University of Hawaii, 2680 Woodlawn Drive, Honolulu, HI, 96822, USA"
+        }
+      ],
+      "name": {
+        "given_name": "K. C.",
+        "surname": "Chambers"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Max Planck Institute for Extraterrestrial Physics, Giessenbachstr. 1, 85748, Garching, Germany"
+        },
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cAugusto Righi\u201d - Alma Mater Studiorum Universit\u00e0 di Bologna, via Piero Gobetti 93/2, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Contarini"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics & Astronomy, University of California Irvine, Irvine, CA, 92697, USA"
+        }
+      ],
+      "name": {
+        "given_name": "A. R.",
+        "surname": "Cooray"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Astronomy, University of Geneva, ch. d\u2019Ecogia 16, 1290, Versoix, Switzerland"
+        }
+      ],
+      "name": {
+        "given_name": "J.",
+        "surname": "Coupon"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INFN-Sezione di Genova, Via Dodecaneso 33, 16146, Genova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Davini"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INFN-Padova, Via Marzolo 8, 35131, Padova, Italy"
+        },
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cG. Galilei\u201d, Universit\u00e0 di Padova, Via Marzolo 8, 35131, Padova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "B.",
+        "surname": "De Caro"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Aix-Marseille Universit\u00e9, CNRS, CNES, LAM, Marseille, France"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "de la Torre"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Astronomy & Physics and Institute for Computational Astrophysics, Saint Mary\u2019s University, 923 Robie Street, Halifax, Nova Scotia, B3H 3C3, Canada"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Desprez"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Departamento F\u00edsica Aplicada, Universidad Polit\u00e9cnica de Cartagena, Campus Muralla del Mar, 30202, Cartagena, Murcia, Spain"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "D\u00edaz-S\u00e1nchez"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica, Universit\u00e0 di Genova, Via Dodecaneso 33, 16146, Genova, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Genova, Via Dodecaneso 33, 16146, Genova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Di Domizio"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Paris-Saclay, CNRS, Institut d\u2019astrophysique spatiale, 91405, Orsay, France"
+        }
+      ],
+      "name": {
+        "given_name": "H.",
+        "surname": "Dole"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Aix-Marseille Universit\u00e9, CNRS/IN2P3, CPPM, Marseille, France"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Escoffier"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cAugusto Righi\u201d - Alma Mater Studiorum Universit\u00e0 di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "A. G.",
+        "surname": "Ferrari"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, Oxford University, Keble Road, Oxford, OX1 3RH, UK"
+        }
+      ],
+      "name": {
+        "given_name": "P. G.",
+        "surname": "Ferreira"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute of Theoretical Astrophysics, University of Oslo, PO Box 1029, Blindern, 0315, Oslo, Norway"
+        }
+      ],
+      "name": {
+        "given_name": "I.",
+        "surname": "Ferrero"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Bologna, Via Irnerio 46, 40126, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "F.",
+        "surname": "Finelli"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, Oxford University, Keble Road, Oxford, OX1 3RH, UK"
+        }
+      ],
+      "name": {
+        "given_name": "L.",
+        "surname": "Gabarra"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Paris Cit\u00e9, CNRS, Astroparticule et Cosmologie, 75013, Paris, France"
+        }
+      ],
+      "name": {
+        "given_name": "K.",
+        "surname": "Ganga"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Instituto de F\u00edsica Te\u00f3rica UAM-CSIC, Campus de Cantoblanco, 28049, Madrid, Spain"
+        }
+      ],
+      "name": {
+        "given_name": "J.",
+        "surname": "Garc\u00eda-Bellido"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute of Space Sciences (ICE, CSIC), Campus UAB, Carrer de Can Magrans, s/n, 08193, Barcelona, Spain"
+        },
+        {
+          "affPubRaw": "Institut d\u2019Estudis Espacials de Catalunya (IEEC), Edifici RDIT, Campus UPC, 08860, Castelldefels, Barcelona, Spain"
+        },
+        {
+          "affPubRaw": "Institute of Cosmology and Gravitation, University of Portsmouth, Portsmouth, PO1 3FX, UK"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Gaztanaga"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INFN-Sezione di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "F.",
+        "surname": "Giacomini"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Computer Science, Aalto University, PO Box 15400, Espoo, 00 076, Finland"
+        },
+        {
+          "affPubRaw": "Department of Physics, P.O. Box 64, 00014, University of Helsinki, Finland"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Gozaliasl"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Ruhr University Bochum, Faculty of Physics and Astronomy, Astronomical Institute (AIRUB), German Centre for Cosmological Lensing (GCCL), 44780, Bochum, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "H.",
+        "surname": "Hildebrandt"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Univ. Grenoble Alpes, CNRS, Grenoble INP, LPSC-IN2P3, 53 Avenue des Martyrs, 38000, Grenoble, France"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Jimenez Munoz"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics and Astronomy, Vesilinnantie 5, 20014 University of Turku, Finland"
+        },
+        {
+          "affPubRaw": "Serco for European Space Agency (ESA), Camino bajo del Castillo, s/n, Urbanizacion Villafranca del Castillo, Villanueva de la Ca\u00f1ada, 28692, Madrid, Spain"
+        }
+      ],
+      "name": {
+        "given_name": "J. J. E.",
+        "surname": "Kajava"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "ARC Centre of Excellence for Dark Matter Particle Physics, Melbourne, Australia"
+        },
+        {
+          "affPubRaw": "Centre for Astrophysics & Supercomputing, Swinburne University of Technology, Victoria, 3122, Australia"
+        }
+      ],
+      "name": {
+        "given_name": "V.",
+        "surname": "Kansal"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "School of Physics and Astronomy, Queen Mary University of London, Mile End Road, London, E1 4NS, UK"
+        },
+        {
+          "affPubRaw": "Department of Physics and Astronomy, University of the Western Cape, Bellville, Cape Town, 7535, South Africa"
+        }
+      ],
+      "name": {
+        "given_name": "D.",
+        "surname": "Karagiannis"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics and Helsinki Institute of Physics, Gustaf H\u00e4llstr\u00f6min katu 2, 00014 University of Helsinki, Finland"
+        }
+      ],
+      "name": {
+        "given_name": "C. C.",
+        "surname": "Kirkpatrick"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "ICTP South American Institute for Fundamental Research, Instituto de F\u00edsica Te\u00f3rica, Universidade Estadual Paulista, S\u00e3o Paulo, Brazil"
+        }
+      ],
+      "name": {
+        "given_name": "L.",
+        "surname": "Legrand"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Centre National d\u2019Etudes Spatiales \u2013 Centre spatial de Toulouse, 18 avenue Edouard Belin, 31401, Toulouse Cedex 9, France"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Libet"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Oskar Klein Centre for Cosmoparticle Physics, Department of Physics, Stockholm University, Stockholm, 106 91, Sweden"
+        },
+        {
+          "affPubRaw": "Astrophysics Group, Blackett Laboratory, Imperial College London, London, SW7 2AZ, UK"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Loureiro"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Univ. Grenoble Alpes, CNRS, Grenoble INP, LPSC-IN2P3, 53 Avenue des Martyrs, 38000, Grenoble, France"
+        }
+      ],
+      "name": {
+        "given_name": "J.",
+        "surname": "Macias-Perez"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Maggio"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Istituto di Astrofisica e Planetologia Spaziali, via del Fosso del Cavaliere, 100, 00100, Roma, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Magliocchetti"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astrofisico di Arcetri, Largo E. Fermi 5, 50125, Firenze, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "F.",
+        "surname": "Mannucci"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica, Sapienza Universit\u00e0 di Roma, Piazzale Aldo Moro 2, 00185, Roma, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Roma, Via Frascati 33, 00078, Monteporzio Catone, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "R.",
+        "surname": "Maoli"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Centro de Astrof\u00edsica da Universidade do Porto, Rua das Estrelas, 4150-762, Porto, Portugal"
+        },
+        {
+          "affPubRaw": "Instituto de Astrof\u00edsica e Ci\u00eancias do Espa\u00e7o, Universidade do Porto, CAUP, Rua das Estrelas, PT4150-762, Porto, Portugal"
+        }
+      ],
+      "name": {
+        "given_name": "C. J. A. P.",
+        "surname": "Martins"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute for Astronomy, University of Edinburgh, Royal Observatory, Blackford Hill, Edinburgh, EH9 3HJ, UK"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Matthew"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Paris-Saclay, CNRS, Institut d\u2019astrophysique spatiale, 91405, Orsay, France"
+        }
+      ],
+      "name": {
+        "given_name": "L.",
+        "surname": "Maurin"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cAugusto Righi\u201d - Alma Mater Studiorum Universit\u00e0 di Bologna, via Piero Gobetti 93/2, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "R. B.",
+        "surname": "Metcalf"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica, Universit\u00e0 di Roma Tor Vergata, Via della Ricerca Scientifica 1, Roma, Italy"
+        },
+        {
+          "affPubRaw": "INFN, Sezione di Roma 2, Via della Ricerca Scientifica 1, Roma, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Migliaccio"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica - Sezione di Astronomia, Universit\u00e0 di Trieste, Via Tiepolo 11, 34131, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "INFN, Sezione di Trieste, Via Valerio 2, 34127, Trieste TS, Italy"
+        },
+        {
+          "affPubRaw": "IFPU, Institute for Fundamental Physics of the Universe, via Beirut 2, 34151, Trieste, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "P.",
+        "surname": "Monaco"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "SISSA, International School for Advanced Studies, Via Bonomea 265, 34136, Trieste TS, Italy"
+        },
+        {
+          "affPubRaw": "ICSC - Centro Nazionale di Ricerca in High Performance Computing, Big Data e Quantum Computing, Via Magnanelli 2, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "IFPU, Institute for Fundamental Physics of the Universe, via Beirut 2, 34151, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "INFN, Sezione di Trieste, Via Valerio 2, 34127, Trieste TS, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "C.",
+        "surname": "Moretti"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Morgante"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute of Cosmology and Gravitation, University of Portsmouth, Portsmouth, PO1 3FX, UK"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Nadathur"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute of Astronomy, University of Cambridge, Madingley Road, Cambridge, CB3 0HA, UK"
+        }
+      ],
+      "name": {
+        "given_name": "N. A.",
+        "surname": "Walton"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INFN-Sezione di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "L.",
+        "surname": "Patrizii"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Max Planck Institute for Extraterrestrial Physics, Giessenbachstr. 1, 85748, Garching, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Pezzotta"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, P.O. Box 64, 00014, University of Helsinki, Finland"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "P\u00f6ntinen"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute of Space Science, Str. Atomistilor, nr. 409 M\u0103gurele, Ilfov, 077125, Romania"
+        }
+      ],
+      "name": {
+        "given_name": "V.",
+        "surname": "Popa"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e4t Bonn, Argelander-Institut f\u00fcr Astronomie, Auf dem H\u00fcgel 71, 53121, Bonn, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "C.",
+        "surname": "Porciani"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Astrophysics, University of Zurich, Winterthur-erstrasse 190, 8057, Zurich, Switzerland"
+        }
+      ],
+      "name": {
+        "given_name": "D.",
+        "surname": "Potter"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica, Universit\u00e0 degli studi di Genova, and INFN-Sezione di Genova, via Dodecaneso 33, 16146, Genova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "I.",
+        "surname": "Risso"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Universit\u00e9 Paris-Saclay, CNRS, Institut d\u2019astrophysique spatiale, 91405, Orsay, France"
+        }
+      ],
+      "name": {
+        "given_name": "P.-F.",
+        "surname": "Rocci"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Theoretical astrophysics, Department of Physics and Astronomy, Uppsala University, Box 515, 751 20, Uppsala, Sweden"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Sahl\u00e9n"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Max Planck Institute for Extraterrestrial Physics, Giessenbachstr. 1, 85748, Garching, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "A. G.",
+        "surname": "S\u00e1nchez"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Institute for Astronomy, University of Edinburgh, Royal Observatory, Blackford Hill, Edinburgh, EH9 3HJ, UK"
+        }
+      ],
+      "name": {
+        "given_name": "J. A.",
+        "surname": "Schewtschenko"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Astrophysics, University of Zurich, Winterthur-erstrasse 190, 8057, Zurich, Switzerland"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Schneider"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Trieste, Via G. B. Tiepolo 11, 34143, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "IFPU, Institute for Fundamental Physics of the Universe, via Beirut 2, 34151, Trieste, Italy"
+        },
+        {
+          "affPubRaw": "INFN, Sezione di Trieste, Via Valerio 2, 34127, Trieste TS, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "E.",
+        "surname": "Sefusatti"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Bologna, Viale Berti Pichat 6/2, 40127, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Sereno"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Max Planck Institute for Extraterrestrial Physics, Giessenbachstr. 1, 85748, Garching, Germany"
+        }
+      ],
+      "name": {
+        "given_name": "J.",
+        "surname": "Steinwagner"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics and Astronomy, University College London, Gower Street, London, WC1E 6BT, UK"
+        }
+      ],
+      "name": {
+        "given_name": "N.",
+        "surname": "Tessore"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INFN-Sezione di Genova, Via Dodecaneso 33, 16146, Genova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Testera"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Astrophysical Sciences, Peyton Hall, Princeton University, Princeton, NJ, 08544, USA"
+        }
+      ],
+      "name": {
+        "given_name": "R.",
+        "surname": "Teyssier"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Cosmic Dawn Center (DAWN), Denmark"
+        },
+        {
+          "affPubRaw": "Niels Bohr Institute, University of Copenhagen, Jagtvej 128, 2200, Copenhagen, Denmark"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Toft"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica, Universit\u00e0 di Genova, Via Dodecaneso 33, 16146, Genova, Italy"
+        },
+        {
+          "affPubRaw": "INAF-Osservatorio Astronomico di Brera, Via Brera 28, 20122, Milano, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Sezione di Genova, Via Dodecaneso 33, 16146, Genova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "S.",
+        "surname": "Tosi"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Dipartimento di Fisica e Astronomia \u201cG. Galilei\u201d, Universit\u00e0 di Padova, Via Marzolo 8, 35131, Padova, Italy"
+        },
+        {
+          "affPubRaw": "INFN-Padova, Via Marzolo 8, 35131, Padova, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "A.",
+        "surname": "Troja"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Astronomy, University of Geneva, ch. d\u2019Ecogia 16, 1290, Versoix, Switzerland"
+        }
+      ],
+      "name": {
+        "given_name": "M.",
+        "surname": "Tucci"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Department of Physics, P.O. Box 64, 00014, University of Helsinki, Finland"
+        },
+        {
+          "affPubRaw": "Helsinki Institute of Physics, Gustaf H\u00e4llstr\u00f6min katu 2, University of Helsinki, Helsinki, Finland"
+        }
+      ],
+      "name": {
+        "given_name": "J.",
+        "surname": "Valiviita"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "INAF-Osservatorio di Astrofisica e Scienza dello Spazio di Bologna, Via Piero Gobetti 93/3, 40129, Bologna, Italy"
+        }
+      ],
+      "name": {
+        "given_name": "D.",
+        "surname": "Vergani"
+      }
+    },
+    {
+      "affiliation": [
+        {
+          "affPubRaw": "Center for Cosmology and Particle Physics, Department of Physics, New York University, New York, NY, 10003, USA"
+        },
+        {
+          "affPubRaw": "Center for Computational Astrophysics, Flatiron Institute, 162 5th Avenue, 10010, New York, NY, USA"
+        }
+      ],
+      "name": {
+        "given_name": "G.",
+        "surname": "Verza"
+      }
+    }
+  ],
+  "copyright": {
+    "statement": "\u00a9 The Authors 2024",
+    "status": true
+  },
+  "editorialHistory": {
+    "acceptedDate": "2024-07-08",
+    "receivedDates": [
+      "2024-04-14"
+    ]
+  },
+  "esources": [
+    {
+      "location": "https://www.aanda.org/articles/aa/full_html/2024/10/aa50368-24/aa50368-24.html",
+      "source": "pub_html"
+    },
+    {
+      "location": "https://www.aanda.org/articles/aa/pdf/2024/10/aa50368-24.pdf",
+      "source": "pub_pdf"
+    }
+  ],
+  "keywords": [
+    {
+      "keyString": "cosmological parameters",
+      "keySystem": "misc"
+    },
+    {
+      "keyString": "dark energy",
+      "keySystem": "misc"
+    },
+    {
+      "keyString": "large-scale structure of Universe",
+      "keySystem": "misc"
+    }
+  ],
+  "openAccess": {
+    "license": "Open Access article, published by EDP Sciences, under the terms of the Creative Commons Attribution License (https://creativecommons.org/licenses/by/4.0), which permits unrestricted use, distribution, and reproduction in any medium, provided the original work is properly cited.",
+    "licenseURL": "https://www.edpsciences.org/en/",
+    "open": true
+  },
+  "pagination": {
+    "electronicID": "A30",
+    "pageCount": "16"
+  },
+  "persistentIDs": [
+    {
+      "DOI": "10.1051/0004-6361/202450368"
+    }
+  ],
+  "pubDate": {
+    "electrDate": "2024-09-30",
+    "printDate": "2024-10-00"
+  },
+  "publication": {
+    "ISSN": [
+      {
+        "issnString": "0004-6361",
+        "pubtype": "ppub"
+      },
+      {
+        "issnString": "1432-0746",
+        "pubtype": "epub"
+      }
+    ],
+    "pubName": "Astronomy & Astrophysics",
+    "pubYear": "2024",
+    "publisher": "EDP Sciences",
+    "volumeNum": "690"
+  },
+  "publisherIDs": [
+    {
+      "Identifier": "aa50368-24",
+      "attribute": "publisher-id"
+    },
+    {
+      "Identifier": "2024A%26A...690A..30E",
+      "attribute": "other"
+    }
+  ],
+  "recordData": {
+    "createdTime": "",
+    "loadFormat": "JATS",
+    "loadLocation": "",
+    "loadType": "fromFile",
+    "parsedTime": "",
+    "recordOrigin": ""
+  },
+  "references": [
+    "<ref id=\"R1\"><mixed-citation publication-type=\"journal\"><string-name><surname>Abbott</surname>, <given-names>T. M. C.</given-names></string-name>, <string-name><surname>Aguena</surname>, <given-names>M.</given-names></string-name>, <string-name><surname>Alarcon</surname>, <given-names>A.</given-names></string-name>, et al. <year>2022</year>, <source>Phys. Rev. D</source>, <volume>105</volume>, <fpage>023520</fpage></mixed-citation></ref>",
+    "<ref id=\"R2\"><mixed-citation publication-type=\"journal\"><string-name><surname>Abramo</surname>, <given-names>L. R.</given-names></string-name>, <string-name><surname>Dinarte Ferri</surname>, <given-names>J. V.</given-names></string-name>, <string-name><surname>Tashiro</surname>, <given-names>I. L.</given-names></string-name>, &amp; <string-name><surname>Loureiro</surname>, <given-names>A.</given-names></string-name> <year>2022</year>, <source>J. Cosmology Astropart. Phys.</source>, <volume>8</volume>, <fpage>073</fpage></mixed-citation></ref>",
+    "<ref id=\"R3\"><mixed-citation publication-type=\"web\"><string-name><surname>Albrecht</surname>, <given-names>A.</given-names></string-name>, <string-name><surname>Bernstein</surname>, <given-names>G.</given-names></string-name>, <string-name><surname>Cahn</surname>, <given-names>R.</given-names></string-name>, et al. <year>2006</year>, <source>arXiv e-prints</source> [<ext-link ext-link-type=\"uri\" xlink:href=\"https://arxiv.org/abs/astro-ph/0609591\">arXiv:astro-ph/0609591</ext-link>]</mixed-citation></ref>",
+    "<ref id=\"R4\"><mixed-citation publication-type=\"journal\"><string-name><surname>Alcock</surname>, <given-names>C.</given-names></string-name>, &amp; <string-name><surname>Paczynski</surname>, <given-names>B.</given-names></string-name> <year>1979</year>, <source>Nature</source>, <volume>281</volume>, <fpage>358</fpage></mixed-citation></ref>",
+    "<ref id=\"R5\"><mixed-citation publication-type=\"journal\"><string-name><surname>Alimi</surname>, <given-names>J. M.</given-names></string-name>, <string-name><surname>Valls-Gabaud</surname>, <given-names>D.</given-names></string-name>, &amp; <string-name><surname>Blanchard</surname>, <given-names>A.</given-names></string-name> <year>1988</year>, <source>A&amp;A</source>, <volume>206</volume>, <fpage>L11</fpage></mixed-citation></ref>",
+    "<ref id=\"R6\"><mixed-citation publication-type=\"journal\"><string-name><surname>Amendola</surname>, <given-names>L.</given-names></string-name>, <string-name><surname>Appleby</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Avgoustidis</surname>, <given-names>A.</given-names></string-name>, et al. <year>2018</year>, <source>Liv. Rev. Relativ.</source>, <volume>21</volume>, <fpage>2</fpage></mixed-citation></ref>",
+    "<ref id=\"R7\"><mixed-citation publication-type=\"journal\"><string-name><surname>Aubourg</surname>, <given-names>\u00c9.</given-names></string-name>, <string-name><surname>Bailey</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Bautista</surname>, <given-names>J. E.</given-names></string-name>, et al. <year>2015</year>, <source>Phys. Rev. D</source>, <volume>92</volume>, <fpage>123516</fpage></mixed-citation></ref>",
+    "<ref id=\"R8\"><mixed-citation publication-type=\"journal\"><string-name><surname>Blanchard</surname>, <given-names>A.</given-names></string-name> <year>2022</year>, <source>Universe</source>, <volume>8</volume>, <fpage>479</fpage></mixed-citation></ref>",
+    "<ref id=\"R9\"><mixed-citation publication-type=\"journal\"><string-name><surname>Chevallier</surname>, <given-names>M.</given-names></string-name>, &amp; <string-name><surname>Polarski</surname>, <given-names>D.</given-names></string-name> <year>2001</year>, <source>Int. J. Mod. Phys.</source>, <volume>D10</volume>, <fpage>213</fpage></mixed-citation></ref>",
+    "<ref id=\"R10\"><mixed-citation publication-type=\"journal\"><string-name><surname>Cropper</surname>, <given-names>M.</given-names></string-name>, <string-name><surname>Pottinger</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Azzollini</surname>, <given-names>R.</given-names></string-name>, et al. <year>2018</year>, <source>SPIE</source>, <volume>10698</volume>, <fpage>709</fpage></mixed-citation></ref>",
+    "<ref id=\"R11\"><mixed-citation publication-type=\"journal\"><string-name><surname>Eisenstein</surname>, <given-names>D. J.</given-names></string-name>, <string-name><surname>Zehavi</surname>, <given-names>I.</given-names></string-name>, <string-name><surname>Hogg</surname>, <given-names>D. W.</given-names></string-name>, et al. <year>2005</year>, <source>ApJ</source>, <volume>633</volume>, <fpage>560</fpage></mixed-citation></ref>",
+    "<ref id=\"R12\"><mixed-citation publication-type=\"journal\"><collab>Euclid Collaboration</collab> (<string-name><surname>Blanchard</surname>, <given-names>A.</given-names></string-name>, et al.) <year>2020</year>, <source>A&amp;A</source>, <volume>642</volume>, <fpage>A191</fpage></mixed-citation></ref>",
+    "<ref id=\"R13\"><mixed-citation publication-type=\"web\"><collab>Euclid Collaboration</collab> (<string-name><surname>Cropper</surname>, <given-names>M.</given-names></string-name>, et al.) <year>2024</year>a, <source>A&amp;A</source>, submitted [<ext-link ext-link-type=\"uri\" xlink:href=\"https://arxiv.org/abs/2405.13492\">arXiv:2405.13492</ext-link>]</mixed-citation></ref>",
+    "<ref id=\"R14\"><mixed-citation publication-type=\"web\"><collab>Euclid Collaboration</collab> (<string-name><surname>Jahnke</surname>, <given-names>K.</given-names></string-name>, et al.) <year>2024</year>b, <source>A&amp;A</source>, in press, <ext-link ext-link-type=\"uri\" xlink:href=\"https://doi.org/10.1051/0004-6361/202450786\">https://doi.org/10.1051/0004-6361/202450786</ext-link></mixed-citation></ref>",
+    "<ref id=\"R15\"><mixed-citation publication-type=\"web\"><collab>Euclid Collaboration</collab> (<string-name><surname>Mellier</surname>, <given-names>Y.</given-names></string-name>, et al.) <year>2024</year>c, <source>A&amp;A</source>, in press, <ext-link ext-link-type=\"uri\" xlink:href=\"https://doi.org/10.1051/0004-6361/202450010\">https://doi.org/10.1051/0004-6361/202450010</ext-link></mixed-citation></ref>",
+    "<ref id=\"R16\"><mixed-citation publication-type=\"journal\"><string-name><surname>Hamaus</surname>, <given-names>N.</given-names></string-name>, <string-name><surname>Seljak</surname>, <given-names>U.</given-names></string-name>, <string-name><surname>Desjacques</surname>, <given-names>V.</given-names></string-name>, <string-name><surname>Smith</surname>, <given-names>R. E.</given-names></string-name>, &amp; <string-name><surname>Baldauf</surname>, <given-names>T.</given-names></string-name> <year>2010</year>, <source>Phys. Rev. D</source>, <volume>82</volume>, <fpage>043515</fpage></mixed-citation></ref>",
+    "<ref id=\"R17\"><mixed-citation publication-type=\"journal\"><string-name><surname>Heymans</surname>, <given-names>C.</given-names></string-name>, <string-name><surname>Tr\u00f6ster</surname>, <given-names>T.</given-names></string-name>, <string-name><surname>Asgari</surname>, <given-names>M.</given-names></string-name>, et al. <year>2021</year>, <source>A&amp;A</source>, <volume>646</volume>, <fpage>A140</fpage></mixed-citation></ref>",
+    "<ref id=\"R18\"><mixed-citation publication-type=\"journal\"><string-name><surname>Hu</surname>, <given-names>W.</given-names></string-name>, &amp; <string-name><surname>Sawicki</surname>, <given-names>I.</given-names></string-name> <year>2007</year>, <source>Phys. Rev. D</source>, <volume>76</volume>, <fpage>104043</fpage></mixed-citation></ref>",
+    "<ref id=\"R19\"><mixed-citation publication-type=\"journal\"><string-name><surname>Kilbinger</surname>, <given-names>M.</given-names></string-name> <year>2015</year>, <source>Rep. Prog. Phys.</source>, <volume>78</volume>, <fpage>086901</fpage></mixed-citation></ref>",
+    "<ref id=\"R20\"><mixed-citation publication-type=\"journal\"><string-name><surname>Lahav</surname>, <given-names>O.</given-names></string-name>, <string-name><surname>Lilje</surname>, <given-names>P. ?.</given-names></string-name>, <string-name><surname>Primack</surname>, <given-names>J. R.</given-names></string-name>, &amp; <string-name><surname>Rees</surname>, <given-names>M. J.</given-names></string-name> <year>1991</year>, <source>MNRAS</source>, <volume>251</volume>, <fpage>128</fpage></mixed-citation></ref>",
+    "<ref id=\"R21\"><mixed-citation publication-type=\"web\"><string-name><surname>Laureijs</surname>, <given-names>R.</given-names></string-name>, <string-name><surname>Amiaux</surname>, <given-names>J.</given-names></string-name>, <string-name><surname>Arduini</surname>, <given-names>S.</given-names></string-name>, et al. <year>2011</year>, <source>arXiv e-prints</source> [<ext-link ext-link-type=\"uri\" xlink:href=\"https://arxiv.org/abs/1110.3193\">arXiv:1110.3193</ext-link>]</mixed-citation></ref>",
+    "<ref id=\"R22\"><mixed-citation publication-type=\"web\"><string-name><surname>Lesgourgues</surname>, <given-names>J.</given-names></string-name> <year>2011</year>, <source>arXiv e-prints</source> [<ext-link ext-link-type=\"uri\" xlink:href=\"https://arxiv.org/abs/1104.2932\">arXiv:1104.2932</ext-link>]</mixed-citation></ref>",
+    "<ref id=\"R23\"><mixed-citation publication-type=\"journal\"><string-name><surname>Lewis</surname>, <given-names>A.</given-names></string-name>, <string-name><surname>Challinor</surname>, <given-names>A.</given-names></string-name>, &amp; <string-name><surname>Lasenby</surname>, <given-names>A.</given-names></string-name> <year>2000</year>, <source>ApJ</source>, <volume>538</volume>, <fpage>473</fpage></mixed-citation></ref>",
+    "<ref id=\"R24\"><mixed-citation publication-type=\"journal\"><string-name><surname>Linder</surname>, <given-names>E. V.</given-names></string-name> <year>2003</year>, <source>Phys. Rev. Lett.</source>, <volume>90</volume>, <fpage>091301</fpage></mixed-citation></ref>",
+    "<ref id=\"R25\"><mixed-citation publication-type=\"journal\"><string-name><surname>Linder</surname>, <given-names>E. V.</given-names></string-name> <year>2005</year>, <source>Phys. Rev. D</source>, <volume>72</volume>, <fpage>043529</fpage></mixed-citation></ref>",
+    "<ref id=\"R26\"><mixed-citation publication-type=\"journal\"><string-name><surname>LoVerde</surname>, <given-names>M.</given-names></string-name>, &amp; <string-name><surname>Afshordi</surname>, <given-names>N.</given-names></string-name> <year>2008</year>, <source>Phys. Rev. D</source>, <volume>78</volume>, <fpage>123506</fpage></mixed-citation></ref>",
+    "<ref id=\"R27\"><mixed-citation publication-type=\"web\"><string-name><surname>Ly</surname>, <given-names>A.</given-names></string-name>, <string-name><surname>Marsman</surname>, <given-names>M.</given-names></string-name>, <string-name><surname>Verhagen</surname>, <given-names>J.</given-names></string-name>, <string-name><surname>Grasman</surname>, <given-names>R.</given-names></string-name>, &amp; <string-name><surname>Wagenmakers</surname>, <given-names>E.-J.</given-names></string-name> <year>2017</year>, <source>arXiv e-prints</source> [<ext-link ext-link-type=\"uri\" xlink:href=\"https://arxiv.org/abs/1705.01064\">arXiv: 1705.01064</ext-link>]</mixed-citation></ref>",
+    "<ref id=\"R28\"><mixed-citation publication-type=\"journal\"><string-name><surname>Maciaszek</surname>, <given-names>T.</given-names></string-name>, <string-name><surname>Ealet</surname>, <given-names>A.</given-names></string-name>, <string-name><surname>Gillard</surname>, <given-names>W.</given-names></string-name>, et al. <year>2022</year>, <source>SPIE Conf. Ser.</source>, <volume>12180</volume>, <fpage>121801K</fpage></mixed-citation></ref>",
+    "<ref id=\"R29\"><mixed-citation publication-type=\"journal\"><string-name><surname>McDonald</surname>, <given-names>P.</given-names></string-name>, &amp; <string-name><surname>Seljak</surname>, <given-names>U.</given-names></string-name> <year>2009</year>, <source>J. Cosmology Astropart. Phys.</source>, <volume>10</volume>, <fpage>007</fpage></mixed-citation></ref>",
+    "<ref id=\"R30\"><mixed-citation publication-type=\"journal\"><string-name><surname>Passaglia</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Manzotti</surname>, <given-names>A.</given-names></string-name>, &amp; <string-name><surname>Dodelson</surname>, <given-names>S.</given-names></string-name> <year>2017</year>, <source>Phys. Rev. D</source>, <volume>95</volume>, <fpage>123508</fpage></mixed-citation></ref>",
+    "<ref id=\"R31\"><mixed-citation publication-type=\"journal\"><string-name><surname>Percival</surname>, <given-names>W. J.</given-names></string-name>, &amp; <string-name><surname>White</surname>, <given-names>M.</given-names></string-name> <year>2009</year>, <source>MNRAS</source>, <volume>393</volume>, <fpage>297</fpage></mixed-citation></ref>",
+    "<ref id=\"R32\"><mixed-citation publication-type=\"journal\"><string-name><surname>Pozzetti</surname>, <given-names>L.</given-names></string-name>, <string-name><surname>Hirata</surname>, <given-names>C. M.</given-names></string-name>, <string-name><surname>Geach</surname>, <given-names>J. E.</given-names></string-name>, et al. <year>2016</year>, <source>A&amp;A</source>, <volume>590</volume>, <fpage>A3</fpage></mixed-citation></ref>",
+    "<ref id=\"R33\"><mixed-citation publication-type=\"journal\"><string-name><surname>Seljak</surname>, <given-names>U.</given-names></string-name> <year>2009</year>, <source>Phys. Rev. Lett.</source>, <volume>102</volume>, <fpage>021302</fpage></mixed-citation></ref>",
+    "<ref id=\"R34\"><mixed-citation publication-type=\"journal\"><string-name><surname>Seljak</surname>, <given-names>U.</given-names></string-name>, <string-name><surname>Hamaus</surname>, <given-names>N.</given-names></string-name>, &amp; <string-name><surname>Desjacques</surname>, <given-names>V.</given-names></string-name> <year>2009</year>, <source>Phys. Rev. Lett.</source>, <volume>103</volume>, <fpage>091303</fpage></mixed-citation></ref>",
+    "<ref id=\"R35\"><mixed-citation publication-type=\"journal\"><string-name><surname>Sugiyama</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Miyatake</surname>, <given-names>H.</given-names></string-name>, <string-name><surname>More</surname>, <given-names>S.</given-names></string-name>, et al. <year>2023</year>, <source>Phys. Rev. D</source>, <volume>108</volume>, <fpage>123521</fpage></mixed-citation></ref>",
+    "<ref id=\"R36\"><mixed-citation publication-type=\"journal\"><string-name><surname>Tanidis</surname>, <given-names>K.</given-names></string-name>, &amp; <string-name><surname>Camera</surname>, <given-names>S.</given-names></string-name> <year>2021</year>, <source>MNRAS</source>, <volume>502</volume>, <fpage>2952</fpage></mixed-citation></ref>",
+    "<ref id=\"R37\"><mixed-citation publication-type=\"journal\"><string-name><surname>Tanidis</surname>, <given-names>K.</given-names></string-name>, <string-name><surname>Cardone</surname>, <given-names>V. F.</given-names></string-name>, <string-name><surname>Martinelli</surname>, <given-names>M.</given-names></string-name>, et al. <year>2024</year>, <source>A&amp;A</source>, <volume>683</volume>, <fpage>A17</fpage></mixed-citation></ref>",
+    "<ref id=\"R38\"><mixed-citation publication-type=\"journal\"><string-name><surname>Taylor</surname>, <given-names>P. L.</given-names></string-name>, &amp; <string-name><surname>Markovic</surname>, <given-names>K.</given-names></string-name> <year>2022</year>, <source>Phys. Rev. D</source>, <volume>106</volume>, <fpage>063536</fpage></mixed-citation></ref>",
+    "<ref id=\"R39\"><mixed-citation publication-type=\"journal\"><string-name><surname>Tessore</surname>, <given-names>N.</given-names></string-name> <year>2017</year>, <source>MNRAS</source>, <volume>471</volume>, <fpage>L57</fpage></mixed-citation></ref>",
+    "<ref id=\"R40\"><mixed-citation publication-type=\"journal\"><string-name><surname>Tutusaus</surname>, <given-names>I.</given-names></string-name>, <string-name><surname>Martinelli</surname>, <given-names>M.</given-names></string-name>, <string-name><surname>Cardone</surname>, <given-names>V. F.</given-names></string-name>, et al. <year>2020</year>, <source>A&amp;A</source>, <volume>643</volume>, <fpage>A70</fpage></mixed-citation></ref>",
+    "<ref id=\"R41\"><mixed-citation publication-type=\"journal\"><string-name><surname>Wang</surname>, <given-names>Y.</given-names></string-name> <year>2008</year>, <source>Phys. Rev. D</source>, <volume>77</volume>, <fpage>123525</fpage></mixed-citation></ref>",
+    "<ref id=\"R42\"><mixed-citation publication-type=\"journal\"><string-name><surname>Wang</surname>, <given-names>Y.</given-names></string-name>, &amp; <string-name><surname>Zhao</surname>, <given-names>G.-B.</given-names></string-name> <year>2020</year>, <source>Res. Astron. Astrophys.</source>, <volume>20</volume>, <fpage>158</fpage></mixed-citation></ref>",
+    "<ref id=\"R43\"><mixed-citation publication-type=\"journal\"><string-name><surname>Wang</surname>, <given-names>M. S.</given-names></string-name>, <string-name><surname>Avila</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Bianchi</surname>, <given-names>D.</given-names></string-name>, <string-name><surname>Crittenden</surname>, <given-names>R.</given-names></string-name>, &amp; <string-name><surname>Percival</surname>, <given-names>W. J.</given-names></string-name> <year>2020</year>, <source>JCAP</source> <volume>10</volume>, <fpage>022</fpage></mixed-citation></ref>",
+    "<ref id=\"R44\"><mixed-citation publication-type=\"journal\"><string-name><surname>Yahia-Cherif</surname>, <given-names>S.</given-names></string-name>, <string-name><surname>Blanchard</surname>, <given-names>A.</given-names></string-name>, <string-name><surname>Camera</surname>, <given-names>S.</given-names></string-name>, et al. <year>2021</year>, <source>A&amp;A</source>, <volume>649</volume>, <fpage>A52</fpage></mixed-citation></ref>"
+  ],
+  "subtitle": {
+    "textEnglish": "XLVII. Improving cosmological constraints using a new multi-tracer method with the spectroscopic and photometric samples"
+  },
+  "title": {
+    "textEnglish": "Euclid preparation"
+  }
+}

--- a/tests/test_jats.py
+++ b/tests/test_jats.py
@@ -23,6 +23,7 @@ class TestJATS(unittest.TestCase):
         filenames = [
             "jats_edp_jnwpu_40_96",
             "jats_edp_aa_661_70",
+            "jats_edp_null_nested_collab_aa50368-24",
             "jats_nature_41467_2023_Article_40261_nlm",
             "jats_nature_natsd_12_7375",
             "jats_nature_natas_tmp",


### PR DESCRIPTION
Issue with nested collaborations without tag -- attempt to insert `None` into a tag raises BeautifulSoup exception.  This patch checks for the existence of the variable before inserting.